### PR TITLE
VB-2320 Display open / closed capacity as separate columns

### DIFF
--- a/server/views/pages/prisons/viewSessionTemplates.njk
+++ b/server/views/pages/prisons/viewSessionTemplates.njk
@@ -112,7 +112,7 @@
           {%- set rows = (rows.push([
             {
               html: '<h3 class="govuk-heading-s govuk-!-margin-bottom-0 govuk-!-margin-top-3">' + day | capitalize + "</h3>",
-              colspan: 8
+              colspan: 9
             }
             ]), rows) %}
 
@@ -134,10 +134,14 @@
                   attributes: { "data-test": "template-start-end-time" }
                 },
                 {
-                  html: "Open: " + sessionTemplate.openCapacity
-                    + "<br>Closed: " + sessionTemplate.closedCapacity,
+                  text: sessionTemplate.openCapacity,
                   classes: "nowrap",
-                  attributes: { "data-test": "template-capacity" }
+                  attributes: { "data-test": "template-capacity-open" }
+                },
+                {
+                  text: sessionTemplate.closedCapacity,
+                  classes: "nowrap",
+                  attributes: { "data-test": "template-capacity-closed" }
                 },
                 {
                   text: sessionTemplate.validFromDate | formatDate('dd MMM yyyy'),
@@ -177,7 +181,10 @@
               text: "Time"
             },
             {
-              text: "Capacity"
+              text: "Open"
+            },
+            {
+              text: "Closed"
             },
             {
               text: "Valid from"

--- a/server/views/pages/prisons/viewSingleSessionTemplate.njk
+++ b/server/views/pages/prisons/viewSingleSessionTemplate.njk
@@ -81,7 +81,7 @@
               text: "Day of week"
             },
             value: {
-              text: sessionTemplate.dayOfWeek
+              text: sessionTemplate.dayOfWeek | capitalize
             }
           },
           { 


### PR DESCRIPTION
* View visit session templates - display open / closed capacity as separate columns
* View single session template - show days as e.g. "Monday" instead of "MONDAY"