### PR TITLE
Tweak templates listing to give more space

### DIFF
--- a/server/utils/nunjucksSetup.test.ts
+++ b/server/utils/nunjucksSetup.test.ts
@@ -146,4 +146,46 @@ describe('Nunjucks Filters', () => {
       expect($('body').text()).toBe('')
     })
   })
+
+  describe('pluralise', () => {
+    describe('Regular plurals', () => {
+      it('should return plural form when count is 0', () => {
+        compiledTemplate = nunjucks.compile('{{ "table" | pluralise(0) }}', njkEnv)
+        const $ = cheerio.load(compiledTemplate.render())
+        expect($('body').text()).toBe('tables')
+      })
+
+      it('should return singular form when count is 1', () => {
+        compiledTemplate = nunjucks.compile('{{ "table" | pluralise(1) }}', njkEnv)
+        const $ = cheerio.load(compiledTemplate.render())
+        expect($('body').text()).toBe('table')
+      })
+
+      it('should return plural form when count is 2', () => {
+        compiledTemplate = nunjucks.compile('{{ "table" | pluralise(2) }}', njkEnv)
+        const $ = cheerio.load(compiledTemplate.render())
+        expect($('body').text()).toBe('tables')
+      })
+    })
+
+    describe('Irregular plurals', () => {
+      it('should return plural form when count is 0', () => {
+        compiledTemplate = nunjucks.compile('{{ "child" | pluralise(0, "children") }}', njkEnv)
+        const $ = cheerio.load(compiledTemplate.render())
+        expect($('body').text()).toBe('children')
+      })
+
+      it('should return singular form when count is 1', () => {
+        compiledTemplate = nunjucks.compile('{{ "child" | pluralise(1, "children") }}', njkEnv)
+        const $ = cheerio.load(compiledTemplate.render())
+        expect($('body').text()).toBe('child')
+      })
+
+      it('should return plural form when count is 2', () => {
+        compiledTemplate = nunjucks.compile('{{ "child" | pluralise(2, "children") }}', njkEnv)
+        const $ = cheerio.load(compiledTemplate.render())
+        expect($('body').text()).toBe('children')
+      })
+    })
+  })
 })

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -74,5 +74,7 @@ export function registerNunjucks(app: express.Express): Environment {
     return dateToFormat ? format(parseISO(dateToFormat), dateFormat) : null
   })
 
+  njkEnv.addFilter('pluralise', (word, count, plural = `${word}s`) => (count === 1 ? word : plural))
+
   return njkEnv
 }

--- a/server/views/pages/prisons/viewSessionTemplates.njk
+++ b/server/views/pages/prisons/viewSessionTemplates.njk
@@ -109,7 +109,7 @@
           {%- set rows = (rows.push([
             {
               html: '<h3 class="govuk-heading-s govuk-!-margin-bottom-0 govuk-!-margin-top-3">' + day | capitalize + "</h3>",
-              colspan: 9
+              colspan: 8
             }
             ]), rows) %}
 
@@ -153,11 +153,7 @@
                   attributes: { "data-test": "template-valid-to-date" }
                 },
                 {
-                  text: sessionTemplate.visitRoom,
-                  attributes: { "data-test": "template-visit-room" }
-                },
-                {
-                  text: sessionTemplate.weeklyFrequency,
+                  text: sessionTemplate.weeklyFrequency + " week" | pluralise(sessionTemplate.weeklyFrequency),
                   attributes: { "data-test": "template-weekly-frequency" }
                 },
                 {
@@ -192,10 +188,7 @@
               text: "Valid to"
             },
             {
-              text: "Visit room"
-            },
-            {
-              text: "Weekly frequency"
+              text: "Frequency"
             },
             {
               text: "Groups"


### PR DESCRIPTION
Make more space in the session templates listing table by:
* removing the Visit room column (not useful info on this page; can be seen when viewing single session template page)
* reducing width of weekly frequency column by shortening label

-----
**BEFORE**

-----

<img width="1298" alt="Screenshot 2023-06-27 at 21 51 56" src="https://github.com/ministryofjustice/hmpps-visits-internal-admin-ui/assets/1441286/2b72eabc-b238-4fb2-9794-dca0fd1b11af">

-----

**AFTER**

-----

<img width="1292" alt="Screenshot 2023-06-27 at 21 50 31" src="https://github.com/ministryofjustice/hmpps-visits-internal-admin-ui/assets/1441286/22439cca-52a2-41ab-8572-8b6a694987f1">

-----