### PR TITLE
Add Prison Register to local Docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,17 +15,23 @@ The easiest way to run the app is to use docker compose to create the service an
 The app requires: 
 * hmpps-auth - for authentication
 * redis - session store and token caching
+* prison-register - look up names of prisons from Prison codes
+* visit-scheduler - all VSiP admin operations
 
 ### Running the app for development
 
 It is simplest to use HMPPS Auth dev, in which case just Redis is needed:
 
-`docker-compose up redis`
+```bash
+docker-compose up redis-vsip-admin -d
+# or, to have prison register running locally too:
+docker-compose up redis-vsip-admin prison-register -d 
+```
 
 
 Or, to start the main services excluding the typescript app: 
 
-`docker-compose up --scale=app=0`
+`docker-compose up --scale=app=0 -d`
 
 Install dependencies using `npm install`, ensuring you are using `node v18.x` and `npm v9.x`
 
@@ -46,6 +52,9 @@ SYSTEM_CLIENT_ID=clientid
 SYSTEM_CLIENT_SECRET=clientsecret
 
 PRISON_REGISTER_API_URL="https://prison-register-dev.hmpps.service.justice.gov.uk"
+# If running prison register locally:
+# PRISON_REGISTER_API_URL: "http://localhost:8082"
+
 VISIT_SCHEDULER_API_URL="https://visit-scheduler-dev.prison.service.justice.gov.uk"
 ```
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,19 @@ services:
       - SPRING_PROFILES_ACTIVE=dev
       - APPLICATION_AUTHENTICATION_UI_ALLOWLIST=0.0.0.0/0
 
+  prison-register:
+    image: quay.io/hmpps/prison-register:latest
+    networks:
+      - hmpps
+    container_name: prison-register
+    ports:
+      - "8082:8080"
+    healthcheck:
+      test: [ "CMD", "curl", "-f", "http://localhost:8080/health" ]
+    environment:
+      - SPRING_PROFILES_ACTIVE=dev
+      - OAUTH_ENDPOINT_URL=https://sign-in-dev.hmpps.service.justice.gov.uk/auth
+
   app:
     build: .
     networks:

--- a/server/services/prisonService.test.ts
+++ b/server/services/prisonService.test.ts
@@ -21,6 +21,7 @@ describe('Prisons service', () => {
 
   const allPrisons = TestData.prisons()
   const prison = TestData.prison()
+  const prisonNames = TestData.prisonNames()
   const prisonRegisterPrisons = TestData.prisonRegisterPrisons()
 
   beforeEach(() => {
@@ -37,14 +38,24 @@ describe('Prisons service', () => {
   })
 
   describe('getPrison', () => {
-    it('should return an array of all supported Prisons', async () => {
+    it('should return Prison and PrisonName', async () => {
       visitSchedulerApiClient.getPrison.mockResolvedValue(prison)
-      const prisonName = 'Hewell (HMP)'
-      const results = await prisonsService.getPrison('user', 'HEI')
+      const results = await prisonsService.getPrison('user', prison.code)
 
       expect(results).toEqual({
         prison,
-        prisonName,
+        prisonName: prisonNames[prison.code],
+      })
+    })
+
+    it('should return Prison and UNKNOWN PrisonName if not in prison register', async () => {
+      const prisonNotInRegister = TestData.prison({ code: 'XYZ' })
+      visitSchedulerApiClient.getPrison.mockResolvedValue(prisonNotInRegister)
+      const results = await prisonsService.getPrison('user', prisonNotInRegister.code)
+
+      expect(results).toEqual({
+        prison: prisonNotInRegister,
+        prisonName: 'UNKNOWN',
       })
     })
   })

--- a/server/services/prisonService.ts
+++ b/server/services/prisonService.ts
@@ -23,7 +23,7 @@ export default class PrisonService {
     const visitSchedulerApiClient = this.visitSchedulerApiClientFactory(token)
 
     const prison = await visitSchedulerApiClient.getPrison(prisonId)
-    const prisonName = this.allPrisonRegisterPrisons[prisonId]
+    const prisonName = this.allPrisonRegisterPrisons[prisonId] || 'UNKNOWN'
 
     return { prison, prisonName }
   }


### PR DESCRIPTION
* add `docker-compose` config to enable Prison register to run locally (handy when dev Prison register is off outside 'standard' hours for power saving...)
* Update `prisonService` to return `'UNKNOWN'` rather than `undefined` if a prison name can't be found for a given prison code