### PR TITLE
Show session template status on prisons page

### DIFF
--- a/server/constants/sessionTemplatesFilterRanges.ts
+++ b/server/constants/sessionTemplatesFilterRanges.ts
@@ -1,7 +1,7 @@
 import { SessionTemplatesRangeType } from '../data/visitSchedulerApiTypes'
 
 const sessionTemplatesFilterRanges: Readonly<Record<SessionTemplatesRangeType, string>> = {
-  CURRENT_OR_FUTURE: 'active and future',
+  CURRENT_OR_FUTURE: 'current and future',
   HISTORIC: 'expired',
   ALL: 'all',
 }

--- a/server/routes/prisons/sessionTemplates/addSessionTemplateController.ts
+++ b/server/routes/prisons/sessionTemplates/addSessionTemplateController.ts
@@ -100,6 +100,10 @@ export default class AddSessionTemplateController {
         .trim()
         .isInt({ min: 1 })
         .withMessage('Enter the date in number format for template start date'),
+      body('validFromDateYear')
+        .trim()
+        .isInt({ min: 1000, max: 9999 })
+        .withMessage('Enter the year for template start date as 4 digits, e.g. 2023'),
       body('validFromDate').custom((_value, { req }) => {
         const theDate = `${req.body.validFromDateYear}-${req.body.validFromDateMonth}-${req.body.validFromDateDay}`
 

--- a/server/views/pages/prisons/viewSessionTemplates.njk
+++ b/server/views/pages/prisons/viewSessionTemplates.njk
@@ -25,6 +25,7 @@
   {% endif %}
 {% endmacro %}
 
+
 {% block content %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
@@ -106,15 +107,23 @@
       {% for day, sessionTemplates in sessionTemplatesByDay -%}
 
         {% if sessionTemplates | length %}
+
+          
+
           {%- set rows = (rows.push([
             {
               html: '<h3 class="govuk-heading-s govuk-!-margin-bottom-0 govuk-!-margin-top-3">' + day | capitalize + "</h3>",
-              colspan: 8
+              colspan: 9
             }
             ]), rows) %}
 
             {%- for sessionTemplate in sessionTemplates -%}
-
+              {% set sessionActiveHtml %}
+                {{ govukTag({
+                  text: "active" if sessionTemplate.active else "inactive",
+                  classes: "govuk-tag--blue" if sessionTemplate.active else "govuk-tag--grey"
+                }) }}
+              {% endset %}
               {%- set groupsListWithCount = [
                 groupCountIfNotEmpty(sessionTemplate.prisonerCategoryGroups, 'Category') | trim,
                 groupCountIfNotEmpty(sessionTemplate.prisonerIncentiveLevelGroups, 'Incentive') | trim,
@@ -126,6 +135,10 @@
                   html: '<a href="/prisons/' + prison.code + '/session-templates/' + sessionTemplate.reference + '">'
                     + sessionTemplate.name + "</a>",
                   attributes: { "data-test": "template-name" }
+                },
+                {
+                  html: sessionActiveHtml,
+                  attributes: { "data-test": "template-status"}
                 },
                 {
                   text: sessionTemplate.sessionTimeSlot.startTime + " to " + sessionTemplate.sessionTimeSlot.endTime,
@@ -171,6 +184,9 @@
           head: [
             {
               text: "Name"
+            },
+            {
+              text: "Status"
             },
             {
               text: "Time"


### PR DESCRIPTION
## Description
Display the status for each session template on the page listing all session templates
Updated the filter name to current and future, as this is what we filter on
Added a test that start date is in the XXXX format