### PR TITLE
VB-2409, add delete functionality to location group

### DIFF
--- a/server/data/visitSchedulerApiClient.test.ts
+++ b/server/data/visitSchedulerApiClient.test.ts
@@ -196,6 +196,21 @@ describe('visitSchedulerApiClient', () => {
     })
   })
 
+  describe('getSingleLocationGroup', () => {
+    it('should return a single location groups', async () => {
+      const singleLocationGroup = TestData.locationGroup()
+
+      fakeVisitSchedulerApi
+        .get(`/admin/location-groups/group/${singleLocationGroup.reference}`)
+        .matchHeader('authorization', `Bearer ${token}`)
+        .reply(200, singleLocationGroup)
+
+      const output = await visitSchedulerApiClient.getSingleLocationGroup(singleLocationGroup.reference)
+
+      expect(output).toEqual(singleLocationGroup)
+    })
+  })
+
   describe('getLocationGroups', () => {
     it('should return all location groups for a prison', async () => {
       const prisonCode = 'HEI'
@@ -209,21 +224,6 @@ describe('visitSchedulerApiClient', () => {
       const output = await visitSchedulerApiClient.getLocationGroups('HEI')
 
       expect(output).toEqual(locationGroups)
-    })
-  })
-
-  describe('getSingleLocationGroup', () => {
-    it('should return a single location groups', async () => {
-      const singleLocationGroup = TestData.locationGroup()
-
-      fakeVisitSchedulerApi
-        .get(`/admin/location-groups/group/${singleLocationGroup.reference}`)
-        .matchHeader('authorization', `Bearer ${token}`)
-        .reply(200, singleLocationGroup)
-
-      const output = await visitSchedulerApiClient.getSingleLocationGroup(singleLocationGroup.reference)
-
-      expect(output).toEqual(singleLocationGroup)
     })
   })
 

--- a/server/data/visitSchedulerApiClient.ts
+++ b/server/data/visitSchedulerApiClient.ts
@@ -133,6 +133,12 @@ export default class VisitSchedulerApiClient {
     })
   }
 
+  async deleteLocationGroup(reference: string): Promise<void> {
+    return this.restClient.delete({
+      path: `/admin/location-groups/group/${reference}`,
+    })
+  }
+
   // Category groups
   async getCategoryGroups(prisonCode: string): Promise<CategoryGroup[]> {
     return this.restClient.get({

--- a/server/routes/prisons/locationGroups/index.ts
+++ b/server/routes/prisons/locationGroups/index.ts
@@ -10,8 +10,9 @@ export default function routes(services: Services): Router {
   const router = Router()
 
   const get = (path: string | string[], handler: RequestHandler) => router.get(path, asyncMiddleware(handler))
+  const post = (path: string | string[], handler: RequestHandler) => router.post(path, asyncMiddleware(handler))
   // const postWithValidation = (path: string | string[], validationChain: ValidationChain[], handler: RequestHandler) =>
-  //   router.post(path, ...validationChain, asyncMiddleware(handler))
+  // router.post(path, ...validationChain, asyncMiddleware(handler))
 
   const locationGroups = new LocationGroupsController(services.prisonService, services.locationGroupService)
   const singleLocationGroup = new SingleLocationGroupController(services.prisonService, services.locationGroupService)
@@ -20,6 +21,7 @@ export default function routes(services: Services): Router {
   get('/prisons/:prisonId([A-Z]{3})/location-groups', locationGroups.view())
   get('/prisons/:prisonId([A-Z]{3})/location-groups/add', addLocationGroup.view())
   get('/prisons/:prisonId([A-Z]{3})/location-groups/:reference', singleLocationGroup.view())
+  post('/prisons/:prisonId([A-Z]{3})/location-groups/:reference/delete', singleLocationGroup.delete())
   // postWithValidation('/prisons/:prisonId/location-groups/add', addLocationGroup.validate(), addLocationGroup.submit())
 
   return router

--- a/server/routes/prisons/locationGroups/singleLocationGroupController.ts
+++ b/server/routes/prisons/locationGroups/singleLocationGroupController.ts
@@ -17,4 +17,20 @@ export default class SingleLocationGroupController {
       return res.render('pages/prisons/locationGroups/viewSingleLocationGroup', { prison, locationGroup })
     }
   }
+
+  public delete(): RequestHandler {
+    return async (req, res) => {
+      const { reference, prisonId } = req.params
+
+      try {
+        await this.locationGroupService.deleteLocationGroup(res.locals.user.username, reference)
+        req.flash('message', `Location group with reference ${reference} deleted.`)
+      } catch (error) {
+        req.flash('errors', [{ msg: `Failed to delete location group with reference - ${reference}` }])
+        return res.redirect(`/prisons/${prisonId}/location-groups/${reference}`)
+      }
+
+      return res.redirect(`/prisons/${prisonId}/location-groups`)
+    }
+  }
 }

--- a/server/services/locationGroupService.ts
+++ b/server/services/locationGroupService.ts
@@ -32,4 +32,11 @@ export default class LocationGroupService {
     )
     return locationGroup
   }
+
+  async deleteLocationGroup(username: string, reference: string): Promise<void> {
+    const token = await this.hmppsAuthClient.getSystemClientToken(username)
+    const visitSchedulerApiClient = this.visitSchedulerApiClientFactory(token)
+
+    return visitSchedulerApiClient.deleteLocationGroup(reference)
+  }
 }


### PR DESCRIPTION
## Description
Added delete for Location groups at the service, data and route layers.

Currently doesn't remove from the table `permitted_session_location` but that's being worked on by the back end devs (No link to the entry in `session_location_group`