### PR TITLE
VB-2469 'Copy' a session template

### DIFF
--- a/server/@types/express/index.d.ts
+++ b/server/@types/express/index.d.ts
@@ -22,6 +22,7 @@ export declare global {
       verified?: boolean
       id: string
       flash(type: 'errors', message: FlashErrorMessage): number
+      flash(type: 'formValues', message: Record<string, string>): number
       logout(done: (err: unknown) => void): void
     }
   }

--- a/server/routes/prisons/sessionTemplates/addSessionTemplateController.ts
+++ b/server/routes/prisons/sessionTemplates/addSessionTemplateController.ts
@@ -26,7 +26,49 @@ export default class AddSessionTemplateController {
     }
   }
 
-  public submit(): RequestHandler {
+  public populateNewFromExisting(): RequestHandler {
+    return async (req, res) => {
+      const { prisonId, reference } = req.params
+
+      const sessionTemplate = await this.sessionTemplateService.getSingleSessionTemplate(
+        res.locals.user.username,
+        reference,
+      )
+
+      const validFromDateSplit = sessionTemplate.sessionDateRange.validFromDate.split('-')
+      const validFromDateYear = validFromDateSplit[0]
+      const validFromDateMonth = validFromDateSplit[1]
+      const validFromDateDay = validFromDateSplit[2]
+
+      const validToDateSplit = (sessionTemplate.sessionDateRange?.validToDate ?? '---').split('-')
+      const validToDateYear = validToDateSplit[0] || undefined
+      const validToDateMonth = validToDateSplit[1] || undefined
+      const validToDateDay = validToDateSplit[2] || undefined
+
+      const formValues = {
+        name: `COPY - ${sessionTemplate.name}`,
+        dayOfWeek: sessionTemplate.dayOfWeek,
+        startTime: sessionTemplate.sessionTimeSlot.startTime,
+        endTime: sessionTemplate.sessionTimeSlot.endTime,
+        weeklyFrequency: sessionTemplate.weeklyFrequency.toString(),
+        validFromDateDay,
+        validFromDateMonth,
+        validFromDateYear,
+        hasEndDate: sessionTemplate.sessionDateRange.validToDate ? 'yes' : undefined,
+        validToDateDay,
+        validToDateMonth,
+        validToDateYear,
+        openCapacity: sessionTemplate.sessionCapacity.open.toString(),
+        closedCapacity: sessionTemplate.sessionCapacity.closed.toString(),
+        visitRoom: sessionTemplate.visitRoom,
+      }
+
+      req.flash('formValues', formValues)
+      return res.redirect(`/prisons/${prisonId}/session-templates/add`)
+    }
+  }
+
+  public add(): RequestHandler {
     return async (req, res) => {
       const { prisonId } = req.params
 

--- a/server/routes/prisons/sessionTemplates/index.ts
+++ b/server/routes/prisons/sessionTemplates/index.ts
@@ -25,8 +25,9 @@ export default function routes(services: Services): Router {
   postWithValidation(
     '/prisons/:prisonId/session-templates/add',
     addSessionTemplate.validate(),
-    addSessionTemplate.submit(),
+    addSessionTemplate.add(),
   )
+  post('/prisons/:prisonId/session-templates/:reference/copy', addSessionTemplate.populateNewFromExisting())
 
   get('/prisons/:prisonId([A-Z]{3})/session-templates', sessionTemplates.view())
 

--- a/server/routes/prisons/sessionTemplates/singleSessionTemplateController.test.ts
+++ b/server/routes/prisons/sessionTemplates/singleSessionTemplateController.test.ts
@@ -33,11 +33,11 @@ afterEach(() => {
 
 describe('Single session template page', () => {
   describe('GET /prisons/{:prisonId}/session-templates/{:reference}', () => {
-    let singleSessionTemplate: SessionTemplate
+    let sessionTemplate: SessionTemplate
 
     beforeEach(() => {
-      singleSessionTemplate = TestData.sessionTemplate()
-      sessionTemplateService.getSingleSessionTemplate.mockResolvedValue(singleSessionTemplate)
+      sessionTemplate = TestData.sessionTemplate()
+      sessionTemplateService.getSingleSessionTemplate.mockResolvedValue(sessionTemplate)
     })
 
     it('should display all session template information', () => {
@@ -47,35 +47,43 @@ describe('Single session template page', () => {
         .expect(res => {
           const $ = cheerio.load(res.text)
           expect($('h1').text()).toContain('Hewell (HMP)')
-          expect($('h1').text()).toContain(singleSessionTemplate.name)
+          expect($('h1').text()).toContain(sessionTemplate.name)
 
-          expect($('.test-template-reference').text()).toContain(singleSessionTemplate.reference)
+          expect($('.test-template-reference').text()).toContain(sessionTemplate.reference)
           expect($('.test-template-dayOfWeek').text()).toContain('Wednesday')
-          expect($('.test-template-startTime').text()).toContain(singleSessionTemplate.sessionTimeSlot.startTime)
-          expect($('.test-template-endTime').text()).toContain(singleSessionTemplate.sessionTimeSlot.endTime)
-          expect($('.test-template-openCapacity').text()).toContain(
-            singleSessionTemplate.sessionCapacity.open.toString(),
-          )
-          expect($('.test-template-closedCapacity').text()).toContain(
-            singleSessionTemplate.sessionCapacity.closed.toString(),
-          )
+          expect($('.test-template-startTime').text()).toContain(sessionTemplate.sessionTimeSlot.startTime)
+          expect($('.test-template-endTime').text()).toContain(sessionTemplate.sessionTimeSlot.endTime)
+          expect($('.test-template-openCapacity').text()).toContain(sessionTemplate.sessionCapacity.open.toString())
+          expect($('.test-template-closedCapacity').text()).toContain(sessionTemplate.sessionCapacity.closed.toString())
           expect($('.test-template-validFromDate').text()).toContain('21 March 2023')
           expect($('.test-template-validToDate').text()).toContain('No end date')
-          expect($('.test-template-visitRoom').text()).toContain(singleSessionTemplate.visitRoom)
+          expect($('.test-template-visitRoom').text()).toContain(sessionTemplate.visitRoom)
           expect($('.test-template-weeklyFrequency').text()).toContain('1')
           expect($('.test-template-locationGroups').text()).toContain('None')
           expect($('.test-template-categoryGroups').text()).toContain('None')
           expect($('.test-template-incentiveGroups').text()).toContain('None')
+
+          // actions
+          expect($('[data-test="template-change-status-form"]').attr('action')).toBe(
+            `/prisons/${prison.code}/session-templates/${sessionTemplate.reference}/deactivate`,
+          )
+          expect($('[data-test="session-template-change-status-button"]').length).toBe(1)
+          expect($('[data-test="template-copy-form"]').attr('action')).toBe(
+            `/prisons/${prison.code}/session-templates/${sessionTemplate.reference}/copy`,
+          )
+          expect($('[data-test="session-template-copy-button"]').length).toBe(1)
+          expect($('[data-test="template-delete-form"]').attr('action')).toBe(
+            `/prisons/${prison.code}/session-templates/${sessionTemplate.reference}/delete`,
+          )
+          expect($('[data-test="session-template-delete-button"]').length).toBe(1)
         })
     })
 
     it('should display all session template information - end date and groups', () => {
-      singleSessionTemplate.sessionDateRange.validToDate = '2023-04-21'
-      singleSessionTemplate.prisonerCategoryGroups = [{ categories: [], name: 'Category group 1', reference: '' }]
-      singleSessionTemplate.prisonerIncentiveLevelGroups = [
-        { incentiveLevels: [], name: 'Incentive group 1', reference: '' },
-      ]
-      singleSessionTemplate.permittedLocationGroups = [{ locations: [], name: 'Location group 1', reference: '' }]
+      sessionTemplate.sessionDateRange.validToDate = '2023-04-21'
+      sessionTemplate.prisonerCategoryGroups = [{ categories: [], name: 'Category group 1', reference: '' }]
+      sessionTemplate.prisonerIncentiveLevelGroups = [{ incentiveLevels: [], name: 'Incentive group 1', reference: '' }]
+      sessionTemplate.permittedLocationGroups = [{ locations: [], name: 'Location group 1', reference: '' }]
 
       return request(app)
         .get('/prisons/HEI/session-templates/-afe.dcc.0f')

--- a/server/views/pages/prisons/sessionTemplates/viewSingleSessionTemplate.njk
+++ b/server/views/pages/prisons/sessionTemplates/viewSingleSessionTemplate.njk
@@ -224,20 +224,30 @@
 
       <h2 class="govuk-heading-m">Change session template status</h2>
       <form action="/prisons/{{ sessionTemplate.prisonId }}/session-templates/{{ sessionTemplate.reference }}/{{ changeStatusAction }}" data-test="template-change-status-form" method="POST" novalidate>
-
         <input type="hidden" name="_csrf" value="{{ csrfToken }}">
 
         {{ govukButton({
-        text: changeStatusAction | capitalize,
-        classes: "govuk-button--warning" if sessionTemplate.active,
-        preventDoubleClick: true,
-        attributes: { "data-test": "session-template-change-status-button" }
-        })}}
+          text: changeStatusAction | capitalize,
+          classes: "govuk-button--warning" if sessionTemplate.active,
+          preventDoubleClick: true,
+          attributes: { "data-test": "session-template-change-status-button" }
+        }) }}
+      </form>
+
+      <h2 class="govuk-heading-m">Copy this template</h2>
+      <p>Start adding a new session template based on this one.</p>
+      <form action="/prisons/{{ sessionTemplate.prisonId }}/session-templates/{{ sessionTemplate.reference }}/copy" data-test="template-copy-form" method="POST" novalidate>
+        <input type="hidden" name="_csrf" value="{{ csrfToken }}">
+        {{ govukButton({
+          text: "Copy",
+          classes: "govuk-button--secondary",
+          preventDoubleClick: true,
+          attributes: { "data-test": "session-template-copy-button" }
+          }) }}
       </form>
 
       <h2 class="govuk-heading-m">Delete session template</h2>
       <form action="/prisons/{{ sessionTemplate.prisonId }}/session-templates/{{ sessionTemplate.reference }}/delete" data-test="template-delete-form" method="POST" novalidate>
-
         <input type="hidden" name="_csrf" value="{{ csrfToken }}">
 
         {{ govukButton({
@@ -246,7 +256,7 @@
           preventDoubleClick: true,
           disabled: (sessionTemplate.active),
           attributes: { "data-test": "session-template-delete-button" }
-        })}}
+        }) }}
 
         {% if sessionTemplate.active %}
           <p>You cannot delete an active template.</p>


### PR DESCRIPTION
Adds a 'Copy' button when viewing a single session template. This opens up the 'Add session template' form with values pre-populated and the name prefixed with `COPY -`.

This doesn't actually make a copy; it just pre-fills values to a new template that is similar to an existing one can be added without needing to re-enter all the data.