### PR TITLE
Standardise handling of API errors

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -27,10 +27,7 @@ export default defineConfig({
         ...auth,
         ...tokenVerification,
 
-        // Prison register API
-        stubPrisons: prisonRegister.stubPrisons,
-
-        // Visit scheduler
+        ...prisonRegister,
         ...visitScheduler,
       })
     },

--- a/integration_tests/e2e/prisons/viewSessionTemplateStatus.cy.ts
+++ b/integration_tests/e2e/prisons/viewSessionTemplateStatus.cy.ts
@@ -9,34 +9,23 @@ context('Change active/inactive session template', () => {
 
   beforeEach(() => {
     const activePrison = TestData.prisonDto({ active: true })
-    deactivatedSessionTemplate = TestData.sessionTemplate({
-      active: false,
-      prisonId: prisonCode,
-      reference: '-ina.dcc.0f',
-    })
-    activeSessionTemplate = TestData.sessionTemplate({ active: true, prisonId: prisonCode, reference: '-act.dcc.0f' })
+    activeSessionTemplate = TestData.sessionTemplate({ active: true })
+    deactivatedSessionTemplate = TestData.sessionTemplate({ active: false })
     cy.task('reset')
     cy.task('stubSignIn')
     cy.task('stubAuthUser')
     cy.task('stubGetPrison', activePrison)
     cy.task('stubPrisons')
     cy.task('stubGetAllPrisons')
-    cy.task('stubGetSessionTemplate', { sessionTemplate: deactivatedSessionTemplate })
-    cy.task('stubGetSessionTemplate', { sessionTemplate: activeSessionTemplate })
-    cy.task('stubActivateSessionTemplate', {
-      sessionTemplate: deactivatedSessionTemplate,
-      activeSessionTemplate,
-    })
-    cy.task('stubDeactivateSessionTemplate', {
-      sessionTemplate: activeSessionTemplate,
-      deactivatedSessionTemplate,
-    })
+    cy.task('stubActivateSessionTemplate')
+    cy.task('stubDeactivateSessionTemplate')
 
     cy.signIn()
   })
 
   it('session template should be deactivated and button should activate', () => {
     // Given
+    cy.task('stubGetSessionTemplate', { sessionTemplate: deactivatedSessionTemplate })
     const viewSessionTemplatePage = Page.createPage(ViewSessionTemplatePage)
 
     // When
@@ -50,10 +39,12 @@ context('Change active/inactive session template', () => {
 
   it('when inactive session template is activated details should change accordingly', () => {
     // Given
+    cy.task('stubGetSessionTemplate', { sessionTemplate: deactivatedSessionTemplate })
     const viewSessionTemplatePage = Page.createPage(ViewSessionTemplatePage)
     viewSessionTemplatePage.goTo(prisonCode, deactivatedSessionTemplate.reference)
 
     // When
+    cy.task('stubGetSessionTemplate', { sessionTemplate: activeSessionTemplate })
     viewSessionTemplatePage.getStatusSwitchButton().click()
 
     // Then
@@ -66,6 +57,7 @@ context('Change active/inactive session template', () => {
 
   it('session template should be activated and button should deactivate', () => {
     // Given
+    cy.task('stubGetSessionTemplate', { sessionTemplate: activeSessionTemplate })
     const viewSessionTemplatePage = Page.createPage(ViewSessionTemplatePage)
 
     // When
@@ -81,10 +73,12 @@ context('Change active/inactive session template', () => {
 
   it('when active session template is deactivated details should change accordingly', () => {
     // Given
+    cy.task('stubGetSessionTemplate', { sessionTemplate: activeSessionTemplate })
     const viewSessionTemplatePage = Page.createPage(ViewSessionTemplatePage)
     viewSessionTemplatePage.goTo(prisonCode, activeSessionTemplate.reference)
 
     // When
+    cy.task('stubGetSessionTemplate', { sessionTemplate: deactivatedSessionTemplate })
     viewSessionTemplatePage.getStatusSwitchButton().click()
 
     // Then

--- a/integration_tests/mockApis/visitScheduler.ts
+++ b/integration_tests/mockApis/visitScheduler.ts
@@ -206,6 +206,9 @@ export default {
       response: {
         status: 400,
         headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+        jsonBody: {
+          developerMessage: `Failed to delete session template with reference - ${sessionTemplate.reference}`,
+        },
       },
     })
   },

--- a/integration_tests/mockApis/visitScheduler.ts
+++ b/integration_tests/mockApis/visitScheduler.ts
@@ -144,13 +144,7 @@ export default {
     })
   },
 
-  stubActivateSessionTemplate: ({
-    sessionTemplate = TestData.sessionTemplate(),
-    activeSessionTemplate = TestData.sessionTemplate({ active: true, reference: '-act.dcc.0f' }),
-  }: {
-    sessionTemplate: SessionTemplate
-    activeSessionTemplate: SessionTemplate
-  }): SuperAgentRequest => {
+  stubActivateSessionTemplate: (sessionTemplate = TestData.sessionTemplate()): SuperAgentRequest => {
     return stubFor({
       request: {
         method: 'PUT',
@@ -159,17 +153,11 @@ export default {
       response: {
         status: 200,
         headers: { 'Content-Type': 'application/json;charset=UTF-8' },
-        jsonBody: activeSessionTemplate,
+        jsonBody: { ...sessionTemplate, active: true },
       },
     })
   },
-  stubDeactivateSessionTemplate: ({
-    sessionTemplate = TestData.sessionTemplate(),
-    deactivatedSessionTemplate = TestData.sessionTemplate({ active: false, reference: '-ina.dcc.0f' }),
-  }: {
-    sessionTemplate: SessionTemplate
-    deactivatedSessionTemplate: SessionTemplate
-  }): SuperAgentRequest => {
+  stubDeactivateSessionTemplate: (sessionTemplate = TestData.sessionTemplate()): SuperAgentRequest => {
     return stubFor({
       request: {
         method: 'PUT',
@@ -178,7 +166,7 @@ export default {
       response: {
         status: 200,
         headers: { 'Content-Type': 'application/json;charset=UTF-8' },
-        jsonBody: deactivatedSessionTemplate,
+        jsonBody: { ...sessionTemplate, active: false },
       },
     })
   },

--- a/server/routes/prisons/categoryGroups/addCategoryGroupController.ts
+++ b/server/routes/prisons/categoryGroups/addCategoryGroupController.ts
@@ -3,6 +3,7 @@ import { ValidationChain, body, validationResult } from 'express-validator'
 import { PrisonService, CategoryGroupService } from '../../../services'
 import { CreateCategoryGroupDto } from '../../../data/visitSchedulerApiTypes'
 import prisonerCategories from '../../../constants/prisonerCategories'
+import { responseErrorToFlashMessage } from '../../../utils/utils'
 
 export default class AddCategoryGroupController {
   public constructor(
@@ -52,7 +53,7 @@ export default class AddCategoryGroupController {
         req.flash('message', `Category group '${reference}' has been created`)
         return res.redirect(`/prisons/${prisonId}/category-groups/${reference}`)
       } catch (error) {
-        req.flash('errors', [{ msg: `${error.status} ${error.message}` }])
+        req.flash('errors', responseErrorToFlashMessage(error))
         req.flash('formValues', req.body)
         return res.redirect(originalUrl)
       }

--- a/server/routes/prisons/categoryGroups/singleCategoryGroupController.ts
+++ b/server/routes/prisons/categoryGroups/singleCategoryGroupController.ts
@@ -1,6 +1,7 @@
 import { RequestHandler } from 'express'
 import { PrisonService, CategoryGroupService } from '../../../services'
 import prisonerCategories from '../../../constants/prisonerCategories'
+import { responseErrorToFlashMessage } from '../../../utils/utils'
 
 export default class SingleCategoryGroupController {
   public constructor(
@@ -34,7 +35,7 @@ export default class SingleCategoryGroupController {
         await this.categoryGroupService.deleteCategoryGroup(res.locals.user.username, reference)
         req.flash('message', `Category group with reference ${reference} deleted.`)
       } catch (error) {
-        req.flash('errors', [{ msg: `Failed to delete category group with reference - ${reference}` }])
+        req.flash('errors', responseErrorToFlashMessage(error))
         return res.redirect(`/prisons/${prisonId}/category-groups/${reference}`)
       }
 

--- a/server/routes/prisons/excludedDates/excludedDatesController.ts
+++ b/server/routes/prisons/excludedDates/excludedDatesController.ts
@@ -1,7 +1,7 @@
 import { RequestHandler } from 'express'
 import { ValidationChain, body, validationResult } from 'express-validator'
 import { PrisonService } from '../../../services'
-import { formatDate } from '../../../utils/utils'
+import { formatDate, responseErrorToFlashMessage } from '../../../utils/utils'
 
 export default class ExcludedDatesController {
   public constructor(private readonly prisonService: PrisonService) {}
@@ -37,7 +37,7 @@ export default class ExcludedDatesController {
         await this.prisonService.addExcludeDate(res.locals.user.username, prisonId, excludeDate)
         req.flash('message', `${excludeDateFormatted} has been successfully added`)
       } catch (error) {
-        req.flash('errors', [{ msg: `Failed to add date ${excludeDateFormatted}` }])
+        req.flash('errors', responseErrorToFlashMessage(error))
       }
 
       return res.redirect(originalUrl)
@@ -55,7 +55,7 @@ export default class ExcludedDatesController {
         await this.prisonService.removeExcludeDate(res.locals.user.username, prisonId, excludeDate)
         req.flash('message', `${excludeDateFormatted} has been successfully removed`)
       } catch (error) {
-        req.flash('errors', [{ msg: `Failed to remove date ${excludeDateFormatted}` }])
+        req.flash('errors', responseErrorToFlashMessage(error))
       }
 
       return res.redirect(`/prisons/${prisonId}/excluded-dates`)

--- a/server/routes/prisons/incentiveGroups/addIncentiveGroupController.ts
+++ b/server/routes/prisons/incentiveGroups/addIncentiveGroupController.ts
@@ -3,6 +3,7 @@ import { ValidationChain, body, validationResult } from 'express-validator'
 import { PrisonService, IncentiveGroupService } from '../../../services'
 import { CreateIncentiveGroupDto } from '../../../data/visitSchedulerApiTypes'
 import incentiveLevels from '../../../constants/incentiveLevels'
+import { responseErrorToFlashMessage } from '../../../utils/utils'
 
 export default class AddIncentiveGroupController {
   public constructor(
@@ -51,7 +52,7 @@ export default class AddIncentiveGroupController {
         req.flash('message', `Incentive level group '${reference}' has been created`)
         return res.redirect(`/prisons/${prisonId}/incentive-groups/${reference}`)
       } catch (error) {
-        req.flash('errors', [{ msg: `${error.status} ${error.message}` }])
+        req.flash('errors', responseErrorToFlashMessage(error))
         req.flash('formValues', req.body)
         return res.redirect(originalUrl)
       }

--- a/server/routes/prisons/incentiveGroups/singleIncentiveGroupController.ts
+++ b/server/routes/prisons/incentiveGroups/singleIncentiveGroupController.ts
@@ -1,6 +1,7 @@
 import { RequestHandler } from 'express'
 import { PrisonService, IncentiveGroupService } from '../../../services'
 import incentiveLevels from '../../../constants/incentiveLevels'
+import { responseErrorToFlashMessage } from '../../../utils/utils'
 
 export default class SingleIncentiveGroupController {
   public constructor(
@@ -37,7 +38,7 @@ export default class SingleIncentiveGroupController {
         await this.incentiveGroupService.deleteIncentiveGroup(res.locals.user.username, reference)
         req.flash('message', `Incentive group with reference ${reference} deleted.`)
       } catch (error) {
-        req.flash('errors', [{ msg: `Failed to delete incentive group with reference - ${reference}` }])
+        req.flash('errors', responseErrorToFlashMessage(error))
         return res.redirect(`/prisons/${prisonId}/incentive-groups/${reference}`)
       }
 

--- a/server/routes/prisons/locationGroups/addLocationGroupController.ts
+++ b/server/routes/prisons/locationGroups/addLocationGroupController.ts
@@ -2,6 +2,7 @@ import { RequestHandler } from 'express'
 import { ValidationChain, body, validationResult } from 'express-validator'
 import { PrisonService, LocationGroupService } from '../../../services'
 import { CreateLocationGroupDto } from '../../../data/visitSchedulerApiTypes'
+import { responseErrorToFlashMessage } from '../../../utils/utils'
 
 export default class AddLocationGroupController {
   public constructor(
@@ -50,7 +51,7 @@ export default class AddLocationGroupController {
         req.flash('message', `Location group '${reference}' has been created`)
         return res.redirect(`/prisons/${prisonId}/location-groups/${reference}`)
       } catch (error) {
-        req.flash('errors', [{ msg: `${error.status} ${error.message}` }])
+        req.flash('errors', responseErrorToFlashMessage(error))
         req.flash('formValues', req.body)
         return res.redirect(originalUrl)
       }

--- a/server/routes/prisons/locationGroups/singleLocationGroupController.ts
+++ b/server/routes/prisons/locationGroups/singleLocationGroupController.ts
@@ -1,5 +1,6 @@
 import { RequestHandler } from 'express'
 import { PrisonService, LocationGroupService } from '../../../services'
+import { responseErrorToFlashMessage } from '../../../utils/utils'
 
 export default class SingleLocationGroupController {
   public constructor(
@@ -30,7 +31,7 @@ export default class SingleLocationGroupController {
         await this.locationGroupService.deleteLocationGroup(res.locals.user.username, reference)
         req.flash('message', `Location group with reference ${reference} deleted.`)
       } catch (error) {
-        req.flash('errors', [{ msg: `Failed to delete location group with reference - ${reference}` }])
+        req.flash('errors', responseErrorToFlashMessage(error))
         return res.redirect(`/prisons/${prisonId}/location-groups/${reference}`)
       }
 

--- a/server/routes/prisons/prisonStatus/prisonStatusController.test.ts
+++ b/server/routes/prisons/prisonStatus/prisonStatusController.test.ts
@@ -1,3 +1,4 @@
+import { BadRequest } from 'http-errors'
 import type { Express } from 'express'
 import request from 'supertest'
 import * as cheerio from 'cheerio'
@@ -124,9 +125,9 @@ describe('Prison status page', () => {
         })
     })
 
-    it('should set error in flash if prison status not changed', () => {
-      prisonService.activatePrison.mockResolvedValue(inactivePrison)
-      const error = { msg: 'Failed to change prison status' }
+    it('should set error in flash if API error when activating prison', () => {
+      prisonService.activatePrison.mockRejectedValue(new BadRequest())
+      const error = { msg: '400 Bad Request' }
 
       return request(app)
         .post('/prisons/HEI/activate')
@@ -155,9 +156,9 @@ describe('Prison status page', () => {
         })
     })
 
-    it('should set error in flash if prison status not changed', () => {
-      prisonService.deactivatePrison.mockResolvedValue(activePrison)
-      const error = { msg: 'Failed to change prison status' }
+    it('should set error in flash if API error when deactivatinig prison', () => {
+      prisonService.deactivatePrison.mockRejectedValue(new BadRequest())
+      const error = { msg: '400 Bad Request' }
 
       return request(app)
         .post('/prisons/HEI/deactivate')

--- a/server/routes/prisons/prisonStatus/prisonStatusController.ts
+++ b/server/routes/prisons/prisonStatus/prisonStatusController.ts
@@ -1,5 +1,6 @@
 import { RequestHandler } from 'express'
 import { PrisonService } from '../../../services'
+import { responseErrorToFlashMessage } from '../../../utils/utils'
 
 export default class PrisonStatusController {
   public constructor(private readonly prisonService: PrisonService) {}
@@ -21,11 +22,11 @@ export default class PrisonStatusController {
     return async (req, res) => {
       const { prisonId } = req.params
 
-      const prison = await this.prisonService.activatePrison(res.locals.user.username, prisonId)
-      if (prison.active) {
+      try {
+        await this.prisonService.activatePrison(res.locals.user.username, prisonId)
         req.flash('message', 'activated')
-      } else {
-        req.flash('errors', [{ msg: 'Failed to change prison status' }])
+      } catch (error) {
+        req.flash('errors', responseErrorToFlashMessage(error))
       }
 
       return res.redirect(`/prisons/${prisonId}/status`)
@@ -36,11 +37,11 @@ export default class PrisonStatusController {
     return async (req, res) => {
       const { prisonId } = req.params
 
-      const prison = await this.prisonService.deactivatePrison(res.locals.user.username, prisonId)
-      if (!prison.active) {
+      try {
+        await this.prisonService.deactivatePrison(res.locals.user.username, prisonId)
         req.flash('message', 'deactivated')
-      } else {
-        req.flash('errors', [{ msg: 'Failed to change prison status' }])
+      } catch (error) {
+        req.flash('errors', responseErrorToFlashMessage(error))
       }
 
       return res.redirect(`/prisons/${prisonId}/status`)

--- a/server/routes/prisons/sessionTemplates/addSessionTemplateController.ts
+++ b/server/routes/prisons/sessionTemplates/addSessionTemplateController.ts
@@ -4,6 +4,7 @@ import { getTime, isValid, parse, parseISO } from 'date-fns'
 import { PrisonService, SessionTemplateService, IncentiveGroupService } from '../../../services'
 import { CreateSessionTemplateDto } from '../../../data/visitSchedulerApiTypes'
 import daysOfWeek from '../../../constants/daysOfWeek'
+import { responseErrorToFlashMessage } from '../../../utils/utils'
 
 export default class AddSessionTemplateController {
   public constructor(
@@ -132,7 +133,7 @@ export default class AddSessionTemplateController {
         req.flash('message', `Session template '${reference}' has been created`)
         return res.redirect(`/prisons/${prisonId}/session-templates/${reference}`)
       } catch (error) {
-        req.flash('errors', [{ msg: `${error.status} ${error.message}` }])
+        req.flash('errors', responseErrorToFlashMessage(error))
         req.flash('formValues', req.body)
         return res.redirect(originalUrl)
       }

--- a/server/routes/prisons/sessionTemplates/singleSessionTemplateController.test.ts
+++ b/server/routes/prisons/sessionTemplates/singleSessionTemplateController.test.ts
@@ -223,7 +223,7 @@ describe('Single session template page', () => {
 
     it('should set error in flash if session template status not deleted', () => {
       // Given
-      const error = { msg: 'Failed to delete session template with reference - -afe.dcc.0f' }
+      const errors: FlashErrorMessage = [{ msg: '400 Bad Request' }]
       sessionTemplateService.deleteSessionTemplate.mockRejectedValue(new BadRequest())
 
       // When
@@ -234,7 +234,7 @@ describe('Single session template page', () => {
         .expect(302)
         .expect('location', `/prisons/HEI/session-templates/-afe.dcc.0f`)
         .expect(() => {
-          expect(flashProvider).toHaveBeenCalledWith('errors', [error])
+          expect(flashProvider).toHaveBeenCalledWith('errors', errors)
           expect(sessionTemplateService.deleteSessionTemplate).toHaveBeenCalledTimes(1)
           expect(sessionTemplateService.deleteSessionTemplate).toHaveBeenCalledWith('user1', '-afe.dcc.0f')
         })

--- a/server/routes/prisons/sessionTemplates/singleSessionTemplateController.test.ts
+++ b/server/routes/prisons/sessionTemplates/singleSessionTemplateController.test.ts
@@ -99,11 +99,9 @@ describe('Single session template page', () => {
   })
 
   describe('POST /prisons/{:prisonId}/session-templates/{:reference}/activate', () => {
-    let deactivatedSessionTemplate: SessionTemplate
     let activeSessionTemplate: SessionTemplate
 
     beforeEach(() => {
-      deactivatedSessionTemplate = TestData.sessionTemplate({ active: false })
       activeSessionTemplate = TestData.sessionTemplate({ active: true })
     })
 
@@ -127,10 +125,10 @@ describe('Single session template page', () => {
       return result
     })
 
-    it('should set error in flash if session template status not changed', () => {
+    it('should set error in flash if API error when changing template status', () => {
       // Given
-      sessionTemplateService.activateSessionTemplate.mockResolvedValue(deactivatedSessionTemplate)
-      const error = { msg: 'Failed to change  session template status' }
+      sessionTemplateService.activateSessionTemplate.mockRejectedValue(new BadRequest())
+      const error = { msg: '400 Bad Request' }
 
       // When
       const result = request(app).post('/prisons/HEI/session-templates/-afe.dcc.0f/activate')
@@ -151,11 +149,9 @@ describe('Single session template page', () => {
 
   describe('POST /prisons/{:prisonId}/session-templates/{:reference}/deactivate', () => {
     let deactivatedSessionTemplate: SessionTemplate
-    let activeSessionTemplate: SessionTemplate
 
     beforeEach(() => {
       deactivatedSessionTemplate = TestData.sessionTemplate({ active: false })
-      activeSessionTemplate = TestData.sessionTemplate({ active: true })
     })
 
     it('should change session template status and set flash message', () => {
@@ -178,10 +174,10 @@ describe('Single session template page', () => {
       return result
     })
 
-    it('should set error in flash if session template status not changed', () => {
+    it('should set error in flash if API error when changing template status', () => {
       // Given
-      sessionTemplateService.deactivateSessionTemplate.mockResolvedValue(activeSessionTemplate)
-      const error = { msg: 'Failed to change session template status' }
+      sessionTemplateService.deactivateSessionTemplate.mockRejectedValue(new BadRequest())
+      const error = { msg: '400 Bad Request' }
 
       // When
       const result = request(app).post('/prisons/HEI/session-templates/-afe.dcc.0f/deactivate')

--- a/server/routes/prisons/sessionTemplates/singleSessionTemplateController.ts
+++ b/server/routes/prisons/sessionTemplates/singleSessionTemplateController.ts
@@ -1,5 +1,6 @@
 import { RequestHandler } from 'express'
 import { PrisonService, SessionTemplateService } from '../../../services'
+import { responseErrorToFlashMessage } from '../../../utils/utils'
 
 export default class SingleSessionTemplateController {
   public constructor(
@@ -70,7 +71,7 @@ export default class SingleSessionTemplateController {
         await this.sessionTemplateService.deleteSessionTemplate(res.locals.user.username, reference)
         req.flash('message', `Session template with reference ${reference} deleted.`)
       } catch (error) {
-        req.flash('errors', [{ msg: `Failed to delete session template with reference - ${reference}` }])
+        req.flash('errors', responseErrorToFlashMessage(error))
         return res.redirect(`/prisons/${prisonId}/session-templates/${reference}`)
       }
 

--- a/server/routes/prisons/sessionTemplates/singleSessionTemplateController.ts
+++ b/server/routes/prisons/sessionTemplates/singleSessionTemplateController.ts
@@ -29,37 +29,31 @@ export default class SingleSessionTemplateController {
 
   public activate(): RequestHandler {
     return async (req, res) => {
-      const { reference } = req.params
+      const { prisonId, reference } = req.params
 
-      const sessionTemplate = await this.sessionTemplateService.activateSessionTemplate(
-        res.locals.user.username,
-        reference,
-      )
-      if (sessionTemplate.active) {
+      try {
+        await this.sessionTemplateService.activateSessionTemplate(res.locals.user.username, reference)
         req.flash('message', 'Template activated')
-      } else {
-        req.flash('errors', [{ msg: 'Failed to change  session template status' }])
+      } catch (error) {
+        req.flash('errors', responseErrorToFlashMessage(error))
       }
 
-      return res.redirect(`/prisons/${sessionTemplate.prisonId}/session-templates/${sessionTemplate.reference}`)
+      return res.redirect(`/prisons/${prisonId}/session-templates/${reference}`)
     }
   }
 
   public deactivate(): RequestHandler {
     return async (req, res) => {
-      const { reference } = req.params
+      const { prisonId, reference } = req.params
 
-      const sessionTemplate = await this.sessionTemplateService.deactivateSessionTemplate(
-        res.locals.user.username,
-        reference,
-      )
-      if (!sessionTemplate.active) {
+      try {
+        await this.sessionTemplateService.deactivateSessionTemplate(res.locals.user.username, reference)
         req.flash('message', 'Template deactivated')
-      } else {
-        req.flash('errors', [{ msg: 'Failed to change session template status' }])
+      } catch (error) {
+        req.flash('errors', responseErrorToFlashMessage(error))
       }
 
-      return res.redirect(`/prisons/${sessionTemplate.prisonId}/session-templates/${sessionTemplate.reference}`)
+      return res.redirect(`/prisons/${prisonId}/session-templates/${reference}`)
     }
   }
 

--- a/server/routes/prisons/supportedPrisonsController.test.ts
+++ b/server/routes/prisons/supportedPrisonsController.test.ts
@@ -134,7 +134,7 @@ describe('Supported prisons', () => {
     })
 
     it('should set a flash error if there is an API error response', () => {
-      const error = { msg: '400 Bad Request' }
+      const expectedError = { msg: '400 Bad Request' }
       prisonService.createPrison.mockRejectedValue(new BadRequest())
 
       return request(app)
@@ -143,7 +143,7 @@ describe('Supported prisons', () => {
         .expect(302)
         .expect('location', `/prisons`)
         .expect(() => {
-          expect(flashProvider).toHaveBeenCalledWith('errors', [error])
+          expect(flashProvider).toHaveBeenCalledWith('errors', [expectedError])
           expect(prisonService.createPrison).toHaveBeenCalledTimes(1)
           expect(prisonService.createPrison).toHaveBeenCalledWith('user1', 'HEI')
         })

--- a/server/routes/prisons/supportedPrisonsController.ts
+++ b/server/routes/prisons/supportedPrisonsController.ts
@@ -1,6 +1,7 @@
 import { RequestHandler } from 'express'
 import { body, validationResult } from 'express-validator'
 import { PrisonService } from '../../services'
+import { responseErrorToFlashMessage } from '../../utils/utils'
 
 export default class SupportedPrisonsController {
   public constructor(private readonly prisonService: PrisonService) {}
@@ -49,7 +50,7 @@ export default class SupportedPrisonsController {
         await this.prisonService.createPrison(res.locals.user.username, prisonId)
         req.flash('message', `${newPrisonName} has been successfully added.`)
       } catch (error) {
-        req.flash('errors', [{ msg: `${error.status} ${error.message}` }])
+        req.flash('errors', responseErrorToFlashMessage(error))
       }
 
       return res.redirect(`/prisons`)

--- a/server/utils/utils.test.ts
+++ b/server/utils/utils.test.ts
@@ -1,4 +1,5 @@
-import { convertToTitleCase, formatDate, initialiseName } from './utils'
+import { SanitisedError } from '../sanitisedError'
+import { convertToTitleCase, formatDate, initialiseName, responseErrorToFlashMessage } from './utils'
 
 describe('convert to title case', () => {
   it.each([
@@ -38,5 +39,35 @@ describe('format a date', () => {
     ['Invalid format', '2022-02-14T10:00:00', '', null],
   ])('%s formatDate(%s, %s) = %s', (_: string, date: string, format: string, expected: string) => {
     expect(formatDate(date, format)).toEqual(expected)
+  })
+})
+
+describe('format a sanitised response error as a flash error message', () => {
+  it('should render error code and message if no developerMessage present', () => {
+    const error = <SanitisedError>{
+      status: 400,
+      message: 'Bad Request',
+    }
+
+    const flashMessage = responseErrorToFlashMessage(error)
+
+    expect(flashMessage.length).toBe(1)
+    expect(flashMessage[0]).toStrictEqual({ msg: '400 Bad Request' })
+  })
+
+  it('should render error code and message plus developerMessage id present', () => {
+    const error = <SanitisedError>{
+      status: 400,
+      message: 'Bad Request',
+      data: {
+        developerMessage: 'API message',
+      },
+    }
+
+    const flashMessage = responseErrorToFlashMessage(error)
+
+    expect(flashMessage.length).toBe(2)
+    expect(flashMessage[0]).toStrictEqual({ msg: '400 Bad Request' })
+    expect(flashMessage[1]).toStrictEqual({ msg: 'API message' })
   })
 })

--- a/server/utils/utils.ts
+++ b/server/utils/utils.ts
@@ -1,4 +1,6 @@
 import { format, parseISO } from 'date-fns'
+import { SanitisedError } from '../sanitisedError'
+import { FlashErrorMessage } from '../@types/visits-admin'
 
 const properCase = (word: string): string =>
   word.length >= 1 ? word[0].toUpperCase() + word.toLowerCase().slice(1) : word
@@ -31,4 +33,18 @@ export const formatDate = (dateToFormat: string, dateFormat = 'd MMMM yyyy'): st
   } catch (error) {
     return null
   }
+}
+
+export const responseErrorToFlashMessage = (error: SanitisedError): FlashErrorMessage => {
+  const flashError = [{ msg: `${error.status} ${error.message}` }]
+
+  if (
+    typeof error.data === 'object' &&
+    'developerMessage' in error.data &&
+    typeof error.data.developerMessage === 'string'
+  ) {
+    flashError.push({ msg: error.data.developerMessage })
+  }
+
+  return flashError
 }


### PR DESCRIPTION
Standardise handling of API errors to include error response code and - if present - `developerMessage` information. Utils function added (`responseErrorToFlashMessage`) to process response errors to be suitable to display in GOVUK Error Summary box. For example:

<img width="873" alt="Screenshot 2023-07-21 at 08 30 59" src="https://github.com/ministryofjustice/hmpps-visits-internal-admin-ui/assets/1441286/83c2d253-fc95-48d5-8a9e-329c6e203f07">

Also, made handling of activating/deactivating prisons and session templates consistent with way other API calls are used in route controllers. 