### PR TITLE
VB-2589, add template stats to view and edit session template pages

### DIFF
--- a/integration_tests/e2e/prisons/addSessionTemplate.cy.ts
+++ b/integration_tests/e2e/prisons/addSessionTemplate.cy.ts
@@ -36,7 +36,7 @@ context('Add session template', () => {
     reference: '-lfe~dcb~fc',
   })
 
-  const requestVisitStatsDto = TestData.requestVisitStatsDto({ visitsFromDate: '2023-08-11' })
+  const requestVisitStatsDto = TestData.requestVisitStatsDto({ visitsFromDate: new Date().toISOString().slice(0, 10) })
   const visitStats = TestData.visitStats()
 
   beforeEach(() => {

--- a/integration_tests/e2e/prisons/addSessionTemplate.cy.ts
+++ b/integration_tests/e2e/prisons/addSessionTemplate.cy.ts
@@ -36,6 +36,9 @@ context('Add session template', () => {
     reference: '-lfe~dcb~fc',
   })
 
+  const requestVisitStatsDto = TestData.requestVisitStatsDto({ visitsFromDate: '2023-08-11' })
+  const visitStats = TestData.visitStats()
+
   beforeEach(() => {
     const activePrison = TestData.prisonDto({ active: true, code: prisonCode })
     sessionTemplate = TestData.sessionTemplate({ active: false, prisonId: prisonCode })
@@ -162,6 +165,11 @@ context('Add session template', () => {
       locationGroupReferences: [locationGroupOne.reference, locationGroupTwo.reference],
     })
     cy.task('stubCreateSessionTemplatePost', { createSessionTemplate, sessionTemplate })
+    cy.task('stubGetTemplateStats', {
+      requestVisitStatsDto,
+      reference: sessionTemplate.reference,
+      visitStats,
+    })
 
     const addSessionTemplatePage = Page.createPage(AddSessionTemplatePage)
     addSessionTemplatePage.goTo(prisonCode)

--- a/integration_tests/e2e/prisons/deleteSessionTemplateFailure.cy.ts
+++ b/integration_tests/e2e/prisons/deleteSessionTemplateFailure.cy.ts
@@ -7,6 +7,9 @@ context('Delete a session template failure', () => {
   const prisonCode = 'HEI'
   let sessionTemplate = null
 
+  const requestVisitStatsDto = TestData.requestVisitStatsDto({ visitsFromDate: '2023-08-11' })
+  const visitStats = TestData.visitStats()
+
   beforeEach(() => {
     const activePrison = TestData.prisonDto({ active: true })
     sessionTemplate = TestData.sessionTemplate({ active: false, prisonId: prisonCode, reference: '-act.dcc.0f' })
@@ -29,6 +32,12 @@ context('Delete a session template failure', () => {
   })
 
   it('when session template is deleted but validation fails on backend user should be shown error message', () => {
+    cy.task('stubGetTemplateStats', {
+      requestVisitStatsDto,
+      reference: sessionTemplate.reference,
+      visitStats,
+    })
+
     // Given
     const viewSessionTemplatePage = Page.createPage(ViewSessionTemplatePage)
     viewSessionTemplatePage.goTo(prisonCode, sessionTemplate.reference)

--- a/integration_tests/e2e/prisons/deleteSessionTemplateFailure.cy.ts
+++ b/integration_tests/e2e/prisons/deleteSessionTemplateFailure.cy.ts
@@ -7,7 +7,7 @@ context('Delete a session template failure', () => {
   const prisonCode = 'HEI'
   let sessionTemplate = null
 
-  const requestVisitStatsDto = TestData.requestVisitStatsDto({ visitsFromDate: '2023-08-11' })
+  const requestVisitStatsDto = TestData.requestVisitStatsDto({ visitsFromDate: new Date().toISOString().slice(0, 10) })
   const visitStats = TestData.visitStats()
 
   beforeEach(() => {

--- a/integration_tests/e2e/prisons/deleteSessionTemplateSuccess.cy.ts
+++ b/integration_tests/e2e/prisons/deleteSessionTemplateSuccess.cy.ts
@@ -8,6 +8,9 @@ context('Delete a session template success', () => {
   const prisonCode = 'HEI'
   let sessionTemplate = null
 
+  const requestVisitStatsDto = TestData.requestVisitStatsDto({ visitsFromDate: '2023-08-11' })
+  const visitStats = TestData.visitStats()
+
   beforeEach(() => {
     const activePrison = TestData.prisonDto({ active: true })
     sessionTemplate = TestData.sessionTemplate({ active: false, prisonId: prisonCode, reference: '-act.dcc.0f' })
@@ -30,6 +33,12 @@ context('Delete a session template success', () => {
   })
 
   it('when session template is deleted user should be redirected to session templates screen', () => {
+    cy.task('stubGetTemplateStats', {
+      requestVisitStatsDto,
+      reference: sessionTemplate.reference,
+      visitStats,
+    })
+
     // Given
     const viewSessionTemplatePage = Page.createPage(ViewSessionTemplatePage)
     viewSessionTemplatePage.goTo(prisonCode, sessionTemplate.reference)

--- a/integration_tests/e2e/prisons/deleteSessionTemplateSuccess.cy.ts
+++ b/integration_tests/e2e/prisons/deleteSessionTemplateSuccess.cy.ts
@@ -8,7 +8,7 @@ context('Delete a session template success', () => {
   const prisonCode = 'HEI'
   let sessionTemplate = null
 
-  const requestVisitStatsDto = TestData.requestVisitStatsDto({ visitsFromDate: '2023-08-11' })
+  const requestVisitStatsDto = TestData.requestVisitStatsDto({ visitsFromDate: new Date().toISOString().slice(0, 10) })
   const visitStats = TestData.visitStats()
 
   beforeEach(() => {

--- a/integration_tests/e2e/prisons/viewSessionTemplateStatus.cy.ts
+++ b/integration_tests/e2e/prisons/viewSessionTemplateStatus.cy.ts
@@ -7,7 +7,7 @@ context('Change active/inactive session template', () => {
   let deactivatedSessionTemplate = null
   let activeSessionTemplate = null
 
-  const requestVisitStatsDto = TestData.requestVisitStatsDto({ visitsFromDate: '2023-08-11' })
+  const requestVisitStatsDto = TestData.requestVisitStatsDto({ visitsFromDate: new Date().toISOString().slice(0, 10) })
   const visitStats = TestData.visitStats()
 
   beforeEach(() => {

--- a/integration_tests/e2e/prisons/viewSessionTemplateStatus.cy.ts
+++ b/integration_tests/e2e/prisons/viewSessionTemplateStatus.cy.ts
@@ -7,6 +7,9 @@ context('Change active/inactive session template', () => {
   let deactivatedSessionTemplate = null
   let activeSessionTemplate = null
 
+  const requestVisitStatsDto = TestData.requestVisitStatsDto({ visitsFromDate: '2023-08-11' })
+  const visitStats = TestData.visitStats()
+
   beforeEach(() => {
     const activePrison = TestData.prisonDto({ active: true })
     activeSessionTemplate = TestData.sessionTemplate({ active: true })
@@ -26,6 +29,11 @@ context('Change active/inactive session template', () => {
   it('session template should be deactivated and button should activate', () => {
     // Given
     cy.task('stubGetSessionTemplate', { sessionTemplate: deactivatedSessionTemplate })
+    cy.task('stubGetTemplateStats', {
+      requestVisitStatsDto,
+      reference: deactivatedSessionTemplate.reference,
+      visitStats,
+    })
     const viewSessionTemplatePage = Page.createPage(ViewSessionTemplatePage)
 
     // When
@@ -40,6 +48,11 @@ context('Change active/inactive session template', () => {
   it('when inactive session template is activated details should change accordingly', () => {
     // Given
     cy.task('stubGetSessionTemplate', { sessionTemplate: deactivatedSessionTemplate })
+    cy.task('stubGetTemplateStats', {
+      requestVisitStatsDto,
+      reference: deactivatedSessionTemplate.reference,
+      visitStats,
+    })
     const viewSessionTemplatePage = Page.createPage(ViewSessionTemplatePage)
     viewSessionTemplatePage.goTo(prisonCode, deactivatedSessionTemplate.reference)
 
@@ -58,6 +71,11 @@ context('Change active/inactive session template', () => {
   it('session template should be activated and button should deactivate', () => {
     // Given
     cy.task('stubGetSessionTemplate', { sessionTemplate: activeSessionTemplate })
+    cy.task('stubGetTemplateStats', {
+      requestVisitStatsDto,
+      reference: deactivatedSessionTemplate.reference,
+      visitStats,
+    })
     const viewSessionTemplatePage = Page.createPage(ViewSessionTemplatePage)
 
     // When
@@ -74,6 +92,11 @@ context('Change active/inactive session template', () => {
   it('when active session template is deactivated details should change accordingly', () => {
     // Given
     cy.task('stubGetSessionTemplate', { sessionTemplate: activeSessionTemplate })
+    cy.task('stubGetTemplateStats', {
+      requestVisitStatsDto,
+      reference: deactivatedSessionTemplate.reference,
+      visitStats,
+    })
     const viewSessionTemplatePage = Page.createPage(ViewSessionTemplatePage)
     viewSessionTemplatePage.goTo(prisonCode, activeSessionTemplate.reference)
 

--- a/integration_tests/mockApis/visitSchedulerMocks.ts
+++ b/integration_tests/mockApis/visitSchedulerMocks.ts
@@ -9,6 +9,8 @@ import {
   LocationGroup,
   CategoryGroup,
   CreateSessionTemplateDto,
+  RequestSessionTemplateVisitStatsDto,
+  SessionTemplateVisitStatsDto,
 } from '../../server/data/visitSchedulerApiTypes'
 
 type Prison = components['schemas']['PrisonDto']
@@ -274,6 +276,35 @@ export default {
         status: 201,
         headers: { 'Content-Type': 'application/json;charset=UTF-8' },
         jsonBody: sessionTemplate,
+      },
+    })
+  },
+
+  stubGetTemplateStats: ({
+    requestVisitStatsDto,
+    reference,
+    visitStats,
+  }: {
+    requestVisitStatsDto: RequestSessionTemplateVisitStatsDto
+    reference: string
+    visitStats: SessionTemplateVisitStatsDto
+  }): SuperAgentRequest => {
+    return stubFor({
+      request: {
+        method: 'POST',
+        url: `/visitScheduler/admin/session-templates/template/${reference}/stats`,
+        bodyPatterns: [
+          {
+            equalToJson: {
+              visitsFromDate: requestVisitStatsDto.visitsFromDate,
+            },
+          },
+        ],
+      },
+      response: {
+        status: 201,
+        headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+        jsonBody: visitStats,
       },
     })
   },

--- a/server/data/visitSchedulerApiClient.test.ts
+++ b/server/data/visitSchedulerApiClient.test.ts
@@ -8,6 +8,7 @@ import {
   CreateLocationGroupDto,
   CreateSessionTemplateDto,
   PrisonDto,
+  RequestSessionTemplateVisitStatsDto,
   UpdateSessionTemplateDto,
 } from './visitSchedulerApiTypes'
 
@@ -265,6 +266,24 @@ describe('visitSchedulerApiClient', () => {
       const output = await visitSchedulerApiClient.updateSessionTemplate(reference, updateSessionTemplateDto)
 
       expect(output).toEqual(updateSessionTemplateDto)
+    })
+  })
+
+  describe('getTemplateStats', () => {
+    it('should return statistics for a session template', async () => {
+      const requestVisitStatsDto = TestData.requestVisitStatsDto()
+      const visitStats = TestData.visitStats()
+      const reference = 'ABC-DEF-GHI'
+      fakeVisitSchedulerApi
+        .post(`/admin/session-templates/template/${reference}/stats`, <RequestSessionTemplateVisitStatsDto>{
+          visitsFromDate: requestVisitStatsDto.visitsFromDate,
+        })
+        .matchHeader('authorization', `Bearer ${token}`)
+        .reply(201, visitStats)
+
+      const output = await visitSchedulerApiClient.getTemplateStats(requestVisitStatsDto, reference)
+
+      expect(output).toEqual(visitStats)
     })
   })
 

--- a/server/data/visitSchedulerApiClient.ts
+++ b/server/data/visitSchedulerApiClient.ts
@@ -12,6 +12,8 @@ import {
   CreateIncentiveGroupDto,
   CreateCategoryGroupDto,
   UpdateSessionTemplateDto,
+  RequestSessionTemplateVisitStatsDto,
+  SessionTemplateVisitStatsDto,
 } from './visitSchedulerApiTypes'
 
 export default class VisitSchedulerApiClient {
@@ -123,6 +125,16 @@ export default class VisitSchedulerApiClient {
     return this.restClient.put({
       path: `/admin/session-templates/template/${reference}`,
       data: updateSessionTemplateDto,
+    })
+  }
+
+  async getTemplateStats(
+    requestVisitStatsDto: RequestSessionTemplateVisitStatsDto,
+    reference: string,
+  ): Promise<SessionTemplateVisitStatsDto> {
+    return this.restClient.post({
+      path: `/admin/session-templates/template/${reference}/stats`,
+      data: requestVisitStatsDto,
     })
   }
 

--- a/server/data/visitSchedulerApiTypes.ts
+++ b/server/data/visitSchedulerApiTypes.ts
@@ -22,3 +22,5 @@ export type CreateSessionTemplateDto = components['schemas']['CreateSessionTempl
 export type SessionTemplate = components['schemas']['SessionTemplateDto']
 export type SessionTemplatesRangeType = operations['getSessionTemplates']['parameters']['query']['rangeType']
 export type UpdateSessionTemplateDto = components['schemas']['UpdateSessionTemplateDto']
+export type RequestSessionTemplateVisitStatsDto = components['schemas']['RequestSessionTemplateVisitStatsDto']
+export type SessionTemplateVisitStatsDto = components['schemas']['SessionTemplateVisitStatsDto']

--- a/server/routes/prisons/sessionTemplates/editSessionTemplateController.test.ts
+++ b/server/routes/prisons/sessionTemplates/editSessionTemplateController.test.ts
@@ -26,7 +26,9 @@ const reference = '-afe.dcc.0f'
 
 beforeEach(() => {
   const sessionTemplate = TestData.sessionTemplate()
+  const visitStats = TestData.visitStats()
   sessionTemplateService.getSingleSessionTemplate.mockResolvedValue(sessionTemplate)
+  sessionTemplateService.getTemplateStats.mockResolvedValue(visitStats)
 
   flashData = {}
   flashProvider.mockImplementation(key => flashData[key])
@@ -63,16 +65,28 @@ describe('Update a session template', () => {
         expect($('h1 span').text().trim()).toBe(prison.name)
         expect($('h1').text().trim()).toContain('Update session template')
 
+        expect($('[data-test="total-booked-test"]').text().trim()).toBe(
+          'This visit session template currently has 4 future visits booked',
+        )
+        expect($('.moj-banner').text().trim()).toContain(
+          'For the date: 8 January 2023, there is currently 4 visits booked',
+        )
+
         expect($(`form[action=${url}][method="POST"]`).length).toBe(1)
 
         expect($('#name').attr('value')).toBe('WEDNESDAY, 2023-03-21, 13:45')
 
         expect($('#validFromDate-validFromDateDay').attr('value')).toBe('21')
         expect($('#validFromDate-validFromDateMonth').attr('value')).toBe('03')
+        expect($('#validFromDate-hint').text().trim()).toContain('This must be before: 8 January 2023')
+
+        expect($('#validToDate-hint').text().trim()).toContain('This must be after: 8 January 2023')
 
         expect($('#openCapacity').attr('value')).toBe('35')
+        expect($('#openCapacity-hint').text().trim()).toContain('The minimum allowed is currently: 3')
 
         expect($('#closedCapacity').attr('value')).toBe('2')
+        expect($('#closedCapacity-hint').text().trim()).toContain('The minimum allowed is currently: 1')
 
         expect($('#visitRoom').attr('value')).toBe('Visits Main Room')
 

--- a/server/routes/prisons/sessionTemplates/editSessionTemplateController.ts
+++ b/server/routes/prisons/sessionTemplates/editSessionTemplateController.ts
@@ -8,7 +8,7 @@ import {
   CategoryGroupService,
   LocationGroupService,
 } from '../../../services'
-import { UpdateSessionTemplateDto } from '../../../data/visitSchedulerApiTypes'
+import { RequestSessionTemplateVisitStatsDto, UpdateSessionTemplateDto } from '../../../data/visitSchedulerApiTypes'
 import { responseErrorToFlashMessage } from '../../../utils/utils'
 
 export default class EditSessionTemplateController {
@@ -82,6 +82,17 @@ export default class EditSessionTemplateController {
         // locationGroupReferences,
       }
 
+      const requestVisitStatsDto: RequestSessionTemplateVisitStatsDto = {
+        visitsFromDate: new Date().toISOString().slice(0, 10),
+      }
+      const visitStats = await this.sessionTemplateService.getTemplateStats(
+        res.locals.user.username,
+        requestVisitStatsDto,
+        reference,
+      )
+      const firstDate = visitStats.visitsByDate[0].visitDate
+      const lastDate = visitStats.visitsByDate[visitStats.visitsByDate.length - 1].visitDate
+
       req.flash('formValues', formValues)
       return res.render('pages/prisons/sessionTemplates/editSingleSessionTemplate', {
         errors: req.flash('errors'),
@@ -92,6 +103,9 @@ export default class EditSessionTemplateController {
         // locationGroups,
         prison,
         reference,
+        visitStats,
+        firstDate,
+        lastDate,
       })
     }
   }

--- a/server/routes/prisons/sessionTemplates/editSessionTemplateController.ts
+++ b/server/routes/prisons/sessionTemplates/editSessionTemplateController.ts
@@ -90,8 +90,12 @@ export default class EditSessionTemplateController {
         requestVisitStatsDto,
         reference,
       )
-      const firstDate = visitStats.visitsByDate[0].visitDate
-      const lastDate = visitStats.visitsByDate[visitStats.visitsByDate.length - 1].visitDate
+      let firstDate = ''
+      let lastDate = ''
+      if (visitStats.visitsByDate.length) {
+        firstDate = visitStats.visitsByDate[0].visitDate
+        lastDate = visitStats.visitsByDate[visitStats.visitsByDate.length - 1].visitDate
+      }
 
       req.flash('formValues', formValues)
       return res.render('pages/prisons/sessionTemplates/editSingleSessionTemplate', {

--- a/server/routes/prisons/sessionTemplates/editSessionTemplateController.ts
+++ b/server/routes/prisons/sessionTemplates/editSessionTemplateController.ts
@@ -96,7 +96,7 @@ export default class EditSessionTemplateController {
         firstDate = visitStats.visitsByDate[0].visitDate
         lastDate = visitStats.visitsByDate[visitStats.visitsByDate.length - 1].visitDate
       }
-      console.log(visitStats)
+
       req.flash('formValues', formValues)
       return res.render('pages/prisons/sessionTemplates/editSingleSessionTemplate', {
         errors: req.flash('errors'),

--- a/server/routes/prisons/sessionTemplates/editSessionTemplateController.ts
+++ b/server/routes/prisons/sessionTemplates/editSessionTemplateController.ts
@@ -96,7 +96,7 @@ export default class EditSessionTemplateController {
         firstDate = visitStats.visitsByDate[0].visitDate
         lastDate = visitStats.visitsByDate[visitStats.visitsByDate.length - 1].visitDate
       }
-
+      console.log(visitStats)
       req.flash('formValues', formValues)
       return res.render('pages/prisons/sessionTemplates/editSingleSessionTemplate', {
         errors: req.flash('errors'),

--- a/server/routes/prisons/sessionTemplates/singleSessionTemplateController.ts
+++ b/server/routes/prisons/sessionTemplates/singleSessionTemplateController.ts
@@ -1,6 +1,7 @@
 import { RequestHandler } from 'express'
 import { PrisonService, SessionTemplateService } from '../../../services'
 import { responseErrorToFlashMessage } from '../../../utils/utils'
+import { RequestSessionTemplateVisitStatsDto } from '../../../data/visitSchedulerApiTypes'
 
 export default class SingleSessionTemplateController {
   public constructor(
@@ -18,11 +19,21 @@ export default class SingleSessionTemplateController {
         reference,
       )
 
+      const requestVisitStatsDto: RequestSessionTemplateVisitStatsDto = {
+        visitsFromDate: new Date().toISOString().slice(0, 10),
+      }
+      const visitStats = await this.sessionTemplateService.getTemplateStats(
+        res.locals.user.username,
+        requestVisitStatsDto,
+        reference,
+      )
+
       return res.render('pages/prisons/sessionTemplates/viewSingleSessionTemplate', {
         errors: req.flash('errors'),
         message: req.flash('message'),
         prison,
         sessionTemplate,
+        visitStats,
       })
     }
   }

--- a/server/routes/testutils/testData.ts
+++ b/server/routes/testutils/testData.ts
@@ -11,6 +11,8 @@ import {
   CreateIncentiveGroupDto,
   CreateCategoryGroupDto,
   UpdateSessionTemplateDto,
+  RequestSessionTemplateVisitStatsDto,
+  SessionTemplateVisitStatsDto,
 } from '../../data/visitSchedulerApiTypes'
 
 export default class TestData {
@@ -188,4 +190,18 @@ export default class TestData {
     prisonId = 'HEI',
     incentiveLevels = ['ENHANCED'],
   }: Partial<CreateIncentiveGroupDto> = {}): CreateIncentiveGroupDto => ({ name, prisonId, incentiveLevels })
+
+  static requestVisitStatsDto = ({
+    visitsFromDate = '2023-01-01',
+  }: Partial<RequestSessionTemplateVisitStatsDto> = {}): RequestSessionTemplateVisitStatsDto => ({ visitsFromDate })
+
+  static visitStats = ({
+    minimumCapacity = { open: 3, closed: 1 },
+    visitCount = 4,
+    visitsByDate = [{ visitCount: 4, visitDate: '2023-01-08' }],
+  }: Partial<SessionTemplateVisitStatsDto> = {}): SessionTemplateVisitStatsDto => ({
+    minimumCapacity,
+    visitCount,
+    visitsByDate,
+  })
 }

--- a/server/services/sessionTemplateService.test.ts
+++ b/server/services/sessionTemplateService.test.ts
@@ -93,4 +93,16 @@ describe('Session template service', () => {
       expect(results).toEqual(singleSessionTemplate)
     })
   })
+
+  describe('getTemplateStats', () => {
+    it('should return the stastics for a session template', async () => {
+      const visitStats = TestData.visitStats()
+      const requestVisitStatsDto = TestData.requestVisitStatsDto()
+      visitSchedulerApiClient.getTemplateStats.mockResolvedValue(visitStats)
+
+      const results = await sessionTemplateService.getTemplateStats('user', requestVisitStatsDto, 'ab-cd-ef')
+
+      expect(results).toEqual(visitStats)
+    })
+  })
 })

--- a/server/services/sessionTemplateService.ts
+++ b/server/services/sessionTemplateService.ts
@@ -2,7 +2,9 @@ import logger from '../../logger'
 import { RestClientBuilder, VisitSchedulerApiClient, HmppsAuthClient } from '../data'
 import {
   CreateSessionTemplateDto,
+  RequestSessionTemplateVisitStatsDto,
   SessionTemplate,
+  SessionTemplateVisitStatsDto,
   SessionTemplatesRangeType,
   UpdateSessionTemplateDto,
 } from '../data/visitSchedulerApiTypes'
@@ -85,5 +87,16 @@ export default class SessionTemplateService {
       `Session template '${sessionTemplate.reference}' updated for prison '${sessionTemplate.prisonId}' by ${username}`,
     )
     return sessionTemplate
+  }
+
+  async getTemplateStats(
+    username: string,
+    requestVisitStatsDto: RequestSessionTemplateVisitStatsDto,
+    reference: string,
+  ): Promise<SessionTemplateVisitStatsDto> {
+    const token = await this.hmppsAuthClient.getSystemClientToken(username)
+    const visitSchedulerApiClient = this.visitSchedulerApiClientFactory(token)
+
+    return visitSchedulerApiClient.getTemplateStats(requestVisitStatsDto, reference)
   }
 }

--- a/server/views/pages/prisons/sessionTemplates/editSingleSessionTemplate.njk
+++ b/server/views/pages/prisons/sessionTemplates/editSingleSessionTemplate.njk
@@ -6,7 +6,7 @@
 {% from "govuk/components/date-input/macro.njk" import govukDateInput %}
 {% from "govuk/components/select/macro.njk" import govukSelect %}
 {% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
-
+{%- from "moj/components/banner/macro.njk" import mojBanner -%}
 
 {% set pageHeaderTitle = 'Update session template' %}
 {% set pageTitle = applicationName + " - " + pageHeaderTitle %}
@@ -28,7 +28,7 @@
   {{ super() }}
 
   <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
+    <div class="govuk-grid-column-three-quarters">
 
       <h1 class="govuk-heading-l">
         <span class="govuk-caption-l">{{ prison.name }}</span>
@@ -62,6 +62,25 @@
         }), locationGroupsItems) %}
       {% endfor %}
 
+      {% set infoBannerHtml %}
+      <p data-test="total-booked-test">This visit session template currently has {{ visitStats.visitCount }} future visits booked</p>
+      {% for stats in visitStats.visitsByDate %}
+        <p>For the date: {{ stats.visitDate | formatDate }}, there is currently {{ stats.visitCount }} visits booked</p>
+      {% endfor %}
+      {% endset %}
+
+      {% if infoBannerHtml | length %}
+        <div class="govuk-grid-row">
+          <div class="govuk-grid-column-two-thirds">
+            {{ mojBanner({
+              type: "information",
+              html: infoBannerHtml,
+              iconFallbackText: "Information"
+            }) }}
+          </div>
+        </div>
+      {% endif %}
+
 
       <form action="/prisons/{{ prison.code }}/session-templates/{{ reference }}/edit" method="POST" novalidate>
         <input type="hidden" name="_csrf" value="{{ csrfToken }}">
@@ -88,7 +107,7 @@
             }
           },
           hint: {
-            text: "For example, 27 3 2023"
+            text: "This must be before: " + (firstDate | formatDate)
           },
           errorMessage: errors | findError('validFromDate'),
           items: [
@@ -126,7 +145,7 @@
               }
             },
             hint: {
-              text: "For example, 27 3 2023"
+              text: "This must be after: " + (lastDate | formatDate)
             },
             items: [
               {
@@ -180,7 +199,7 @@
             classes: "govuk-label--m"
           },
           hint: {
-            text: "What is the open capacity?"
+            text: "What is the open capacity? - The minimum allowed is currently: " + (visitStats.minimumCapacity.open if visitStats.minimumCapacity.open > 0 else 'any')
           },
           classes: "govuk-!-width-one-third",
           id: "openCapacity",
@@ -197,7 +216,7 @@
             classes: "govuk-label--m"
           },
           hint: {
-            text: "What is the closed capacity?"
+            text: "What is the closed capacity? - The minimum allowed is currently: " + (visitStats.minimumCapacity.closed if visitStats.minimumCapacity.closed > 0 else 'any')
           },
           classes: "govuk-!-width-one-third",
           id: "closedCapacity",

--- a/server/views/pages/prisons/sessionTemplates/editSingleSessionTemplate.njk
+++ b/server/views/pages/prisons/sessionTemplates/editSingleSessionTemplate.njk
@@ -107,7 +107,7 @@
             }
           },
           hint: {
-            text: "This must be before: " + (firstDate | formatDate)
+            text: "This must be before: " + firstDate | formatDate if firstDate !== '' else 'Any date can be set'
           },
           errorMessage: errors | findError('validFromDate'),
           items: [
@@ -145,7 +145,7 @@
               }
             },
             hint: {
-              text: "This must be after: " + (lastDate | formatDate)
+            text: "This must be after: " + lastDate | formatDate if lastDate !== '' else 'Any date can be set'
             },
             items: [
               {
@@ -199,7 +199,7 @@
             classes: "govuk-label--m"
           },
           hint: {
-            text: "What is the open capacity? - The minimum allowed is currently: " + (visitStats.minimumCapacity.open if visitStats.minimumCapacity.open > 0 else 'any')
+            text: "The minimum allowed is currently: " + visitStats.minimumCapacity.open if visitStats.minimumCapacity.open > 0 else 'Any capacity can be set'
           },
           classes: "govuk-!-width-one-third",
           id: "openCapacity",
@@ -216,7 +216,7 @@
             classes: "govuk-label--m"
           },
           hint: {
-            text: "What is the closed capacity? - The minimum allowed is currently: " + (visitStats.minimumCapacity.closed if visitStats.minimumCapacity.closed > 0 else 'any')
+            text: "The minimum allowed is currently: " + visitStats.minimumCapacity.closed if visitStats.minimumCapacity.closed > 0 else 'Any capacity can be set'
           },
           classes: "govuk-!-width-one-third",
           id: "closedCapacity",

--- a/server/views/pages/prisons/sessionTemplates/editSingleSessionTemplate.njk
+++ b/server/views/pages/prisons/sessionTemplates/editSingleSessionTemplate.njk
@@ -63,9 +63,9 @@
       {% endfor %}
 
       {% set infoBannerHtml %}
-      <p data-test="total-booked-test">This visit session template currently has {{ visitStats.visitCount }} future visits booked</p>
+      <p data-test="total-booked-test">This visit session template currently has {{ visitStats.visitCount }} future {{ 'visits' if visitStats.visitCount >= 2 else 'visit' }} booked</p>
       {% for stats in visitStats.visitsByDate %}
-        <p>For the date: {{ stats.visitDate | formatDate }}, there is currently {{ stats.visitCount }} visits booked</p>
+        <p>For the date: {{ stats.visitDate | formatDate }}, there is currently {{ stats.visitCount }} {{ 'visits' if stats.visitCount >= 2 else 'visit' }} booked</p>
       {% endfor %}
       {% endset %}
 

--- a/server/views/pages/prisons/sessionTemplates/viewSingleSessionTemplate.njk
+++ b/server/views/pages/prisons/sessionTemplates/viewSingleSessionTemplate.njk
@@ -77,15 +77,15 @@
       {%- endset -%}
 
       {% set infoBannerHtml %}
-      <p data-test="total-booked-test">This visit session template currently has {{ visitStats.visitCount }} future visits booked</p>
+      <p data-test="total-booked-test">This visit session template currently has {{ visitStats.visitCount }} future {{ 'visits' if visitStats.visitCount >= 2 else 'visit' }} booked</p>
       {% for stats in visitStats.visitsByDate %}
-        <p>For the date: {{ stats.visitDate | formatDate }}, there is currently {{ stats.visitCount }} visits booked</p>
+        <p>For the date: {{ stats.visitDate | formatDate }}, there is currently {{ stats.visitCount }} {{ 'visits' if stats.visitCount >= 2 else 'visit' }} booked</p>
       {% endfor %}
       {% endset %}
 
       {% if infoBannerHtml | length %}
         <div class="govuk-grid-row">
-          <div class="govuk-grid-column-two-thirds">
+          <div class="govuk-grid-column-three-quarters">
             {{ mojBanner({
               type: "information",
               html: infoBannerHtml,

--- a/server/views/pages/prisons/sessionTemplates/viewSingleSessionTemplate.njk
+++ b/server/views/pages/prisons/sessionTemplates/viewSingleSessionTemplate.njk
@@ -3,6 +3,7 @@
 {%- from "govuk/components/back-link/macro.njk" import govukBackLink -%}
 {%- from "govuk/components/button/macro.njk" import govukButton -%}
 {%- from "govuk/components/tag/macro.njk" import govukTag -%}
+{%- from "moj/components/banner/macro.njk" import mojBanner -%}
 
 {% set pageHeaderTitle = sessionTemplate.name %}
 {% set pageTitle = applicationName + " - " + pageHeaderTitle %}
@@ -74,6 +75,25 @@
           None
         {%- endif -%}
       {%- endset -%}
+
+      {% set infoBannerHtml %}
+      <p data-test="total-booked-test">This visit session template currently has {{ visitStats.visitCount }} future visits booked</p>
+      {% for stats in visitStats.visitsByDate %}
+        <p>For the date: {{ stats.visitDate | formatDate }}, there is currently {{ stats.visitCount }} visits booked</p>
+      {% endfor %}
+      {% endset %}
+
+      {% if infoBannerHtml | length %}
+        <div class="govuk-grid-row">
+          <div class="govuk-grid-column-two-thirds">
+            {{ mojBanner({
+              type: "information",
+              html: infoBannerHtml,
+              iconFallbackText: "Information"
+            }) }}
+          </div>
+        </div>
+      {% endif %}
 
       {{ govukSummaryList({
         rows: [


### PR DESCRIPTION
## Description
Display session template statistics on the view and edit single session template pages
Also display relevant information for each field on the edit session template page - so the user can make an informed decision

Changes to the stats API will be added under a separate PR when released