### PR TITLE
VB-2698, location level codes bug fix

### DIFF
--- a/server/data/visitSchedulerApiTypes.ts
+++ b/server/data/visitSchedulerApiTypes.ts
@@ -13,12 +13,7 @@ export type IncentiveLevels = IncentiveLevelGroup['incentiveLevels'][number]
 // Location groups
 export type LocationGroup = components['schemas']['SessionLocationGroupDto']
 export type CreateLocationGroupDto = components['schemas']['CreateLocationGroupDto']
-export type singleLocation = {
-  levelOneCode: string
-  levelTwoCode?: string
-  levelThreeCode?: string
-  levelFourCode?: string
-}
+
 // Prison
 export type PrisonDto = components['schemas']['PrisonDto']
 

--- a/server/data/visitSchedulerApiTypes.ts
+++ b/server/data/visitSchedulerApiTypes.ts
@@ -13,7 +13,12 @@ export type IncentiveLevels = IncentiveLevelGroup['incentiveLevels'][number]
 // Location groups
 export type LocationGroup = components['schemas']['SessionLocationGroupDto']
 export type CreateLocationGroupDto = components['schemas']['CreateLocationGroupDto']
-
+export type singleLocation = {
+  levelOneCode: string
+  levelTwoCode?: string
+  levelThreeCode?: string
+  levelFourCode?: string
+}
 // Prison
 export type PrisonDto = components['schemas']['PrisonDto']
 

--- a/server/routes/prisons/locationGroups/addLocationGroupController.test.ts
+++ b/server/routes/prisons/locationGroups/addLocationGroupController.test.ts
@@ -112,54 +112,35 @@ describe('Add a location group', () => {
         })
     })
 
-    // Sending undefined sets NULL in the database
-    it('should send valid data with some blank levels, and send to orchestration as undefined ', () => {
+    it('should not send entries for blank levels', () => {
       const createLocationGroupDto = TestData.createLocationGroupDto({
-        locations: [
-          { levelOneCode: '1a', levelTwoCode: '2a', levelThreeCode: '3a', levelFourCode: '4a' },
-          { levelOneCode: '1b', levelTwoCode: '2b', levelThreeCode: '3b', levelFourCode: undefined },
-          { levelOneCode: '1c', levelTwoCode: '2c', levelThreeCode: undefined, levelFourCode: undefined },
-          { levelOneCode: '1d', levelTwoCode: undefined, levelThreeCode: undefined, levelFourCode: undefined },
-        ],
+        locations: [{ levelOneCode: '1a' }, { levelOneCode: '1b', levelTwoCode: '2b' }],
       })
 
       const locationGroup = TestData.locationGroup({ ...createLocationGroupDto })
       locationGroupService.createLocationGroup.mockResolvedValue(locationGroup)
 
-      return (
-        request(app)
-          .post(url)
-          .send(`name=${createLocationGroupDto.name}`)
-          // Row 1
-          .send('location[0][levelOneCode]=1a')
-          .send('location[0][levelTwoCode]=2a')
-          .send('location[0][levelThreeCode]=3a')
-          .send('location[0][levelFourCode]=4a')
-          // Row 2
-          .send('location[1][levelOneCode]=1b')
-          .send('location[1][levelTwoCode]=2b')
-          .send('location[1][levelThreeCode]=3b')
-          .send('location[1][levelFourCode]=')
-          // Row 3
-          .send('location[2][levelOneCode]=1c')
-          .send('location[2][levelTwoCode]=2c')
-          .send('location[2][levelThreeCode]=')
-          .send('location[2][levelFourCode]=')
-          // Row 4
-          .send('location[3][levelOneCode]=1d')
-          .send('location[3][levelTwoCode]=')
-          .send('location[3][levelThreeCode]=')
-          .send('location[3][levelFourCode]=')
-
-          .expect(302)
-          .expect('location', `/prisons/${prison.code}/location-groups/${locationGroup.reference}`)
-          .expect(() => {
-            expect(flashProvider).not.toHaveBeenCalledWith('errors')
-            expect(flashProvider).not.toHaveBeenCalledWith('formValues')
-
-            expect(locationGroupService.createLocationGroup).toHaveBeenCalledWith('user1', createLocationGroupDto)
-          })
-      )
+      return request(app)
+        .post(url)
+        .send(`name=${createLocationGroupDto.name}`)
+        .send('location[0][levelOneCode]=1a')
+        .send('location[0][levelTwoCode]=')
+        .send('location[0][levelThreeCode]=')
+        .send('location[0][levelFourCode]=')
+        .send('location[1][levelOneCode]=1b')
+        .send('location[1][levelTwoCode]=2b')
+        .send('location[1][levelThreeCode]=')
+        .send('location[1][levelFourCode]=')
+        .expect(302)
+        .expect('location', `/prisons/${prison.code}/location-groups/${locationGroup.reference}`)
+        .expect(() => {
+          expect(flashProvider).not.toHaveBeenCalledWith('errors')
+          expect(flashProvider).not.toHaveBeenCalledWith('formValues')
+          expect(locationGroupService.createLocationGroup.mock.calls[0]).toStrictEqual([
+            'user1',
+            createLocationGroupDto,
+          ])
+        })
     })
 
     it('should set validation errors for invalid form data and set data in formValues', () => {

--- a/server/routes/prisons/locationGroups/addLocationGroupController.test.ts
+++ b/server/routes/prisons/locationGroups/addLocationGroupController.test.ts
@@ -112,6 +112,56 @@ describe('Add a location group', () => {
         })
     })
 
+    // Sending undefined sets NULL in the database
+    it('should send valid data with some blank levels, and send to orchestration as undefined ', () => {
+      const createLocationGroupDto = TestData.createLocationGroupDto({
+        locations: [
+          { levelOneCode: '1a', levelTwoCode: '2a', levelThreeCode: '3a', levelFourCode: '4a' },
+          { levelOneCode: '1b', levelTwoCode: '2b', levelThreeCode: '3b', levelFourCode: undefined },
+          { levelOneCode: '1c', levelTwoCode: '2c', levelThreeCode: undefined, levelFourCode: undefined },
+          { levelOneCode: '1d', levelTwoCode: undefined, levelThreeCode: undefined, levelFourCode: undefined },
+        ],
+      })
+
+      const locationGroup = TestData.locationGroup({ ...createLocationGroupDto })
+      locationGroupService.createLocationGroup.mockResolvedValue(locationGroup)
+
+      return (
+        request(app)
+          .post(url)
+          .send(`name=${createLocationGroupDto.name}`)
+          // Row 1
+          .send('location[0][levelOneCode]=1a')
+          .send('location[0][levelTwoCode]=2a')
+          .send('location[0][levelThreeCode]=3a')
+          .send('location[0][levelFourCode]=4a')
+          // Row 2
+          .send('location[1][levelOneCode]=1b')
+          .send('location[1][levelTwoCode]=2b')
+          .send('location[1][levelThreeCode]=3b')
+          .send('location[1][levelFourCode]=')
+          // Row 3
+          .send('location[2][levelOneCode]=1c')
+          .send('location[2][levelTwoCode]=2c')
+          .send('location[2][levelThreeCode]=')
+          .send('location[2][levelFourCode]=')
+          // Row 4
+          .send('location[3][levelOneCode]=1d')
+          .send('location[3][levelTwoCode]=')
+          .send('location[3][levelThreeCode]=')
+          .send('location[3][levelFourCode]=')
+
+          .expect(302)
+          .expect('location', `/prisons/${prison.code}/location-groups/${locationGroup.reference}`)
+          .expect(() => {
+            expect(flashProvider).not.toHaveBeenCalledWith('errors')
+            expect(flashProvider).not.toHaveBeenCalledWith('formValues')
+
+            expect(locationGroupService.createLocationGroup).toHaveBeenCalledWith('user1', createLocationGroupDto)
+          })
+      )
+    })
+
     it('should set validation errors for invalid form data and set data in formValues', () => {
       const expectedValidationErrors = [
         expect.objectContaining({ path: 'name', msg: 'Enter a name between 3 and 100 characters long' }),

--- a/server/routes/prisons/locationGroups/addLocationGroupController.ts
+++ b/server/routes/prisons/locationGroups/addLocationGroupController.ts
@@ -1,7 +1,7 @@
 import { RequestHandler } from 'express'
 import { ValidationChain, body, validationResult } from 'express-validator'
 import { PrisonService, LocationGroupService } from '../../../services'
-import { CreateLocationGroupDto, singleLocation } from '../../../data/visitSchedulerApiTypes'
+import { CreateLocationGroupDto, LocationGroup } from '../../../data/visitSchedulerApiTypes'
 import { responseErrorToFlashMessage } from '../../../utils/utils'
 
 export default class AddLocationGroupController {
@@ -37,14 +37,15 @@ export default class AddLocationGroupController {
         return res.redirect(originalUrl)
       }
 
-      const locations: singleLocation[] = []
-      req.body.location.forEach((location: singleLocation) => {
-        locations.push({
-          levelOneCode: location.levelOneCode,
-          levelTwoCode: location.levelTwoCode !== '' ? location.levelTwoCode : undefined,
-          levelThreeCode: location.levelThreeCode !== '' ? location.levelThreeCode : undefined,
-          levelFourCode: location.levelFourCode !== '' ? location.levelFourCode : undefined,
-        })
+      // empty location levels come through as empty strings so need to be removed
+      type LocationLevels = LocationGroup['locations'][number]
+      const locations: LocationLevels[] = []
+      req.body.location.forEach((location: LocationLevels) => {
+        const sanitisedLocation: LocationLevels = Object.fromEntries(
+          Object.entries(location).filter(e => e[1] !== ''),
+        ) as LocationLevels
+
+        locations.push(sanitisedLocation)
       })
 
       const createLocationGroupDto: CreateLocationGroupDto = {

--- a/server/routes/prisons/locationGroups/addLocationGroupController.ts
+++ b/server/routes/prisons/locationGroups/addLocationGroupController.ts
@@ -1,7 +1,7 @@
 import { RequestHandler } from 'express'
 import { ValidationChain, body, validationResult } from 'express-validator'
 import { PrisonService, LocationGroupService } from '../../../services'
-import { CreateLocationGroupDto } from '../../../data/visitSchedulerApiTypes'
+import { CreateLocationGroupDto, singleLocation } from '../../../data/visitSchedulerApiTypes'
 import { responseErrorToFlashMessage } from '../../../utils/utils'
 
 export default class AddLocationGroupController {
@@ -37,10 +37,20 @@ export default class AddLocationGroupController {
         return res.redirect(originalUrl)
       }
 
+      const locations: singleLocation[] = []
+      req.body.location.forEach((location: singleLocation) => {
+        locations.push({
+          levelOneCode: location.levelOneCode,
+          levelTwoCode: location.levelTwoCode !== '' ? location.levelTwoCode : undefined,
+          levelThreeCode: location.levelThreeCode !== '' ? location.levelThreeCode : undefined,
+          levelFourCode: location.levelFourCode !== '' ? location.levelFourCode : undefined,
+        })
+      })
+
       const createLocationGroupDto: CreateLocationGroupDto = {
         name: req.body.name,
         prisonId,
-        locations: req.body.location,
+        locations,
       }
 
       try {


### PR DESCRIPTION
## Description
Send empty location levels as undefined, this then inserts them into the database as NULL - which is what the original sql scripts did.
This then makes the session template the location group is tied to work as expected