### PR TITLE
Refactor primary and sub-navigation

### DIFF
--- a/integration_tests/e2e/prisons/prisonStatus/prisonStatus.cy.ts
+++ b/integration_tests/e2e/prisons/prisonStatus/prisonStatus.cy.ts
@@ -1,7 +1,7 @@
 import TestData from '../../../../server/routes/testutils/testData'
 import HomePage from '../../../pages/home'
 import Page from '../../../pages/page'
-import SupportedPrisonsPage from '../../../pages/prisons/prisonsPage'
+import SupportedPrisonsPage from '../../../pages/prisons/SupportedPrisonsPage'
 import ViewSessionTemplatesPage from '../../../pages/prisons/sessionTemplates/viewSessionTemplatesPage'
 import PrisonStatusPage from '../../../pages/prisons/prisonStatus/prisonStatusPage'
 import { SessionTemplatesRangeType } from '../../../../server/data/visitSchedulerApiTypes'
@@ -31,10 +31,10 @@ context('Supported prisons', () => {
     cy.task('stubGetPrison', inactivePrison)
     cy.task('stubGetSessionTemplates', { prisonCode, rangeType })
 
-    supportedPrisonsPage.selectPrison(prisonCode).click()
+    supportedPrisonsPage.getPrisonByCode(prisonCode).click()
     const viewSessionTemplatePage = Page.verifyOnPage(ViewSessionTemplatesPage)
 
-    viewSessionTemplatePage.statusTab().click()
+    viewSessionTemplatePage.selectStatusTab()
     const prisonStatusPage = Page.verifyOnPage(PrisonStatusPage)
 
     prisonStatusPage.prisonStatusLabel().contains('inactive')
@@ -58,10 +58,10 @@ context('Supported prisons', () => {
     cy.task('stubGetPrison', activePrison)
     cy.task('stubGetSessionTemplates', { prisonCode, rangeType })
 
-    supportedPrisonsPage.selectPrison(prisonCode).click()
+    supportedPrisonsPage.getPrisonByCode(prisonCode).click()
     const viewSessionTemplatePage = Page.verifyOnPage(ViewSessionTemplatesPage)
 
-    viewSessionTemplatePage.statusTab().click()
+    viewSessionTemplatePage.selectStatusTab()
     const prisonStatusPage = Page.verifyOnPage(PrisonStatusPage)
 
     prisonStatusPage.prisonStatusLabel().contains('active')

--- a/integration_tests/e2e/prisons/supportedPrisons.cy.ts
+++ b/integration_tests/e2e/prisons/supportedPrisons.cy.ts
@@ -1,7 +1,7 @@
 import TestData from '../../../server/routes/testutils/testData'
 import HomePage from '../../pages/home'
 import Page from '../../pages/page'
-import SupportedPrisonsPage from '../../pages/prisons/prisonsPage'
+import SupportedPrisonsPage from '../../pages/prisons/SupportedPrisonsPage'
 
 context('Supported prisons', () => {
   beforeEach(() => {

--- a/integration_tests/mockApis/visitScheduler/sessionTemplates.ts
+++ b/integration_tests/mockApis/visitScheduler/sessionTemplates.ts
@@ -12,8 +12,8 @@ import {
 export default {
   stubGetSessionTemplates: ({
     prisonCode,
-    rangeType,
-    sessionTemplates = [TestData.sessionTemplate()],
+    rangeType = 'CURRENT_OR_FUTURE',
+    sessionTemplates = [],
   }: {
     prisonCode: string
     rangeType: SessionTemplatesRangeType

--- a/integration_tests/pages/prisonPage.ts
+++ b/integration_tests/pages/prisonPage.ts
@@ -1,0 +1,16 @@
+import Page, { PageElement } from './page'
+
+export default class PrisonPage extends Page {
+  // Sub-navigation sections
+  selectSessionTemplatesTab = (): PageElement => cy.get('[data-test="tab-session-templates"]').click()
+
+  selectExcludedDatesTab = (): PageElement => cy.get('[data-test="tab-excluded-dates"]').click()
+
+  selectCategoryGroupsTab = (): PageElement => cy.get('[data-test="tab-category-groups"]').click()
+
+  selectIncentiveGroupsTab = (): PageElement => cy.get('[data-test="tab-incentive-groups"]').click()
+
+  selectLocationGroupsTab = (): PageElement => cy.get('[data-test="tab-location-groups"]').click()
+
+  selectStatusTab = (): PageElement => cy.get('[data-test="tab-status"]').click()
+}

--- a/integration_tests/pages/prisons/SupportedPrisonsPage.ts
+++ b/integration_tests/pages/prisons/SupportedPrisonsPage.ts
@@ -1,11 +1,12 @@
-import Page, { PageElement } from '../page'
+import type { PageElement } from '../page'
+import PrisonPage from '../prisonPage'
 
-export default class SupportedPrisonsPage extends Page {
+export default class SupportedPrisonsPage extends PrisonPage {
   constructor() {
     super('Supported prisons')
   }
 
-  selectPrison = (prisonId: string): PageElement => cy.get(`a[href="/prisons/${prisonId}/session-templates"]`)
+  getPrisonByCode = (prisonId: string): PageElement => cy.get(`a[href="/prisons/${prisonId}/session-templates"]`)
 
   enterPrisonCode = (prisonId: string): PageElement => cy.get('.govuk-input').type(prisonId)
 

--- a/integration_tests/pages/prisons/prisonStatus/prisonStatusPage.ts
+++ b/integration_tests/pages/prisons/prisonStatus/prisonStatusPage.ts
@@ -1,6 +1,7 @@
-import Page, { PageElement } from '../../page'
+import type { PageElement } from '../../page'
+import PrisonPage from '../../prisonPage'
 
-export default class prisonStatusPage extends Page {
+export default class prisonStatusPage extends PrisonPage {
   constructor() {
     super('Hewell (HMP)')
   }

--- a/integration_tests/pages/prisons/sessionTemplates/addSessionTemplatePage.ts
+++ b/integration_tests/pages/prisons/sessionTemplates/addSessionTemplatePage.ts
@@ -1,6 +1,6 @@
-import Page from '../../page'
+import PrisonPage from '../../prisonPage'
 
-export default class AddViewSessionTemplatePage extends Page {
+export default class AddViewSessionTemplatePage extends PrisonPage {
   constructor() {
     super('Hewell (HMP)')
   }

--- a/integration_tests/pages/prisons/sessionTemplates/viewSessionTemplatePage.ts
+++ b/integration_tests/pages/prisons/sessionTemplates/viewSessionTemplatePage.ts
@@ -1,6 +1,7 @@
-import Page, { PageElement } from '../../page'
+import type { PageElement } from '../../page'
+import PrisonPage from '../../prisonPage'
 
-export default class ViewSessionTemplatePage extends Page {
+export default class ViewSessionTemplatePage extends PrisonPage {
   constructor() {
     super('Hewell (HMP)')
   }

--- a/integration_tests/pages/prisons/sessionTemplates/viewSessionTemplatesPage.ts
+++ b/integration_tests/pages/prisons/sessionTemplates/viewSessionTemplatesPage.ts
@@ -1,13 +1,12 @@
-import Page, { PageElement } from '../../page'
+import type { PageElement } from '../../page'
+import PrisonPage from '../../prisonPage'
 
-export default class ViewSessionTemplatesPage extends Page {
+export default class ViewSessionTemplatesPage extends PrisonPage {
   constructor() {
     super('Hewell (HMP)')
   }
 
   goTo = (prisonCode: string) => cy.visit(`/prisons/${prisonCode}/session-templates`)
-
-  statusTab = (): PageElement => cy.get('[data-test=tab-status]')
 
   selectTemplatePrison = (prisonId: string, reference: string): PageElement =>
     cy.get(`a[href="/prisons/${prisonId}/session-templates/${reference}"]`)

--- a/server/views/components/subNavigation.njk
+++ b/server/views/components/subNavigation.njk
@@ -1,0 +1,39 @@
+{%- from "moj/components/sub-navigation/macro.njk" import mojSubNavigation -%}
+
+{% macro subNavigation(prisonCode, activeTab) %}
+  {{ mojSubNavigation({
+    label: "Sub navigation",
+    classes: "govuk-!-margin-top-3",
+    items: [{
+      text: "Session templates",
+      href: "/prisons/" + prisonCode + "/session-templates",
+      attributes: { "data-test": "tab-session-templates" },
+      active: activeTab === "session-templates"
+    }, {
+      text: "Excluded dates",
+      href: "/prisons/" + prisonCode + "/excluded-dates",
+      attributes: { "data-test": "tab-excluded-dates" },
+      active: activeTab === "excluded-dates"
+    }, {
+      text: "Category groups",
+      href: "/prisons/" + prisonCode + "/category-groups",
+      attributes: { "data-test": "tab-category-groups" },
+      active: activeTab === "category-groups"
+    }, {
+      text: "Incentive level groups",
+      href: "/prisons/" + prisonCode + "/incentive-groups",
+      attributes: { "data-test": "tab-incentive-groups" },
+      active: activeTab === "incentive-groups"
+    }, {
+      text: "Location groups",
+      href: "/prisons/" + prisonCode + "/location-groups",
+      attributes: { "data-test": "tab-location-groups" },
+      active: activeTab === "location-groups"
+    }, {
+      text: "Status",
+      href: "/prisons/" + prisonCode + "/status",
+      attributes: { "data-test": "tab-status" },
+      active: activeTab === "status"
+    }]
+  }) }}
+{% endmacro %}

--- a/server/views/pages/home.njk
+++ b/server/views/pages/home.njk
@@ -3,20 +3,9 @@
 
 {% set pageHeaderTitle = applicationName %}
 {% set pageTitle = applicationName + " - Home" %}
+{% set activePrimaryNav = "home" %}
 
 {% set mainClasses = "govuk-main-wrapper--auto-spacing" %}
-
-{% set primaryNavItems = [
-  {
-    text: "Home",
-    href: "/",
-    active: true
-  },
-  {
-    text: "Prisons",
-    href: "/prisons"
-  }
-  ] %}
 
 {% block content %}
 

--- a/server/views/pages/prisons/categoryGroups/addCategoryGroup.njk
+++ b/server/views/pages/prisons/categoryGroups/addCategoryGroup.njk
@@ -1,6 +1,5 @@
 {% extends "partials/layout.njk" %}
 {% from "govuk/components/table/macro.njk" import govukTable %}
-{%- from "moj/components/sub-navigation/macro.njk" import mojSubNavigation -%}
 {% from "moj/components/page-header-actions/macro.njk" import mojPageHeaderActions %}
 {%- from "govuk/components/button/macro.njk" import govukButton -%}
 {%- from "govuk/components/input/macro.njk" import govukInput -%}
@@ -8,18 +7,7 @@
 
 {% set pageHeaderTitle = 'Add a category group' %}
 {% set pageTitle = applicationName + " - Category groups - " + pageHeaderTitle %}
-
-{% set primaryNavItems = [
-  {
-    text: "Home",
-    href: "/"
-  },
-  {
-    text: "Prisons",
-    href: "/prisons",
-    active: true
-  }
-] %}
+{% set activePrimaryNav = "prisons" %}
 {% set backLinkHref = "/prisons/" + prison.code + "/category-groups" %}
 
 {% block content %}

--- a/server/views/pages/prisons/categoryGroups/viewCategoryGroups.njk
+++ b/server/views/pages/prisons/categoryGroups/viewCategoryGroups.njk
@@ -1,23 +1,12 @@
 {% extends "partials/layout.njk" %}
 {% from "govuk/components/table/macro.njk" import govukTable %}
-{%- from "moj/components/sub-navigation/macro.njk" import mojSubNavigation -%}
 {%- from "govuk/components/tag/macro.njk" import govukTag -%}
 {% from "moj/components/page-header-actions/macro.njk" import mojPageHeaderActions %}
+{% from "components/subNavigation.njk" import subNavigation %}
 
 {% set pageHeaderTitle = prison.name %}
 {% set pageTitle = applicationName + " - Category groups - " + pageHeaderTitle %}
-
-{% set primaryNavItems = [
-  {
-    text: "Home",
-    href: "/"
-  },
-  {
-    text: "Prisons",
-    href: "/prisons",
-    active: true
-  }
-] %}
+{% set activePrimaryNav = "prisons" %}
 
 {% block content %}
   {{ super() }}
@@ -42,31 +31,7 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
 
-      {{ mojSubNavigation({
-        label: "Sub navigation",
-        classes: "govuk-!-margin-top-3",
-        items: [{
-          text: "Session templates",
-          href: "/prisons/" + prison.code + "/session-templates"
-        }, {
-          text: "Excluded dates",
-          href: "/prisons/" + prison.code + "/excluded-dates"
-        }, {
-          text: "Category groups",
-          href: "/prisons/" + prison.code + "/category-groups",
-          active: true
-        }, {
-          text: "Incentive level groups",
-          href: "/prisons/" + prison.code + "/incentive-groups"
-        }, {
-          text: "Location groups",
-          href: "/prisons/" + prison.code + "/location-groups"
-        }, {
-          text: "Status",
-          href: "/prisons/" + prison.code + "/status",
-          attributes: { "data-test": "tab-status" }
-        }]
-      }) }}
+      {{ subNavigation(prison.code, "category-groups") }}
 
       {{ mojPageHeaderActions({
         heading: {

--- a/server/views/pages/prisons/categoryGroups/viewSingleCategoryGroup.njk
+++ b/server/views/pages/prisons/categoryGroups/viewSingleCategoryGroup.njk
@@ -7,18 +7,7 @@
 
 {% set pageHeaderTitle = categoryGroup.name %}
 {% set pageTitle = applicationName + " - " + pageHeaderTitle %}
-
-{% set primaryNavItems = [
-  {
-    text: "Home",
-    href: "/"
-  },
-  {
-    text: "Prisons",
-    href: "/prisons",
-    active: true
-  }
-  ] %}
+{% set activePrimaryNav = "prisons" %}
 
 {% set backLinkHref = "/prisons/" + prison.code +
   ( "/session-templates/" + sessionTemplateRef if sessionTemplateRef else "/category-groups") %}

--- a/server/views/pages/prisons/excludedDates/viewExcludedDates.njk
+++ b/server/views/pages/prisons/excludedDates/viewExcludedDates.njk
@@ -2,23 +2,13 @@
 {% from "govuk/components/table/macro.njk" import govukTable %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/date-input/macro.njk" import govukDateInput %}
-{%- from "moj/components/sub-navigation/macro.njk" import mojSubNavigation -%}
 {%- from "govuk/components/tag/macro.njk" import govukTag -%}
 {% from "moj/components/page-header-actions/macro.njk" import mojPageHeaderActions %}
+{% from "components/subNavigation.njk" import subNavigation %}
 
 {% set pageHeaderTitle = prison.name %}
 {% set pageTitle = applicationName + " - Excluded dates - " + pageHeaderTitle %}
-{% set primaryNavItems = [
-  {
-    text: "Home",
-    href: "/"
-  },
-  {
-    text: "Prisons",
-    href: "/prisons",
-    active: true
-  }
-] %}
+{% set activePrimaryNav = "prisons" %}
 
 {% block content %}
   {{ super() }}
@@ -43,31 +33,7 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
 
-      {{ mojSubNavigation({
-        label: "Sub navigation",
-        classes: "govuk-!-margin-top-3",
-        items: [{
-          text: "Session templates",
-          href: "/prisons/" + prison.code + "/session-templates"
-        }, {
-          text: "Excluded dates",
-          href: "/prisons/" + prison.code + "/excluded-dates",
-          active: true
-        }, {
-          text: "Category groups",
-          href: "/prisons/" + prison.code + "/category-groups"
-        }, {
-          text: "Incentive level groups",
-          href: "/prisons/" + prison.code + "/incentive-groups"
-        }, {
-          text: "Location groups",
-          href: "/prisons/" + prison.code + "/location-groups"
-        }, {
-          text: "Status",
-          href: "/prisons/" + prison.code + "/status",
-          attributes: { "data-test": "tab-status" }
-        }]
-      }) }}
+      {{ subNavigation(prison.code, "excluded-dates") }}
 
       <h2 class="govuk-heading-m">Excluded dates</h2>
 

--- a/server/views/pages/prisons/incentiveGroups/addIncentiveGroup.njk
+++ b/server/views/pages/prisons/incentiveGroups/addIncentiveGroup.njk
@@ -1,6 +1,5 @@
 {% extends "partials/layout.njk" %}
 {% from "govuk/components/table/macro.njk" import govukTable %}
-{%- from "moj/components/sub-navigation/macro.njk" import mojSubNavigation -%}
 {% from "moj/components/page-header-actions/macro.njk" import mojPageHeaderActions %}
 {%- from "govuk/components/button/macro.njk" import govukButton -%}
 {%- from "govuk/components/input/macro.njk" import govukInput -%}
@@ -8,18 +7,7 @@
 
 {% set pageHeaderTitle = 'Add an incentive level group' %}
 {% set pageTitle = applicationName + " - Incentive groups - " + pageHeaderTitle %}
-
-{% set primaryNavItems = [
-  {
-    text: "Home",
-    href: "/"
-  },
-  {
-    text: "Prisons",
-    href: "/prisons",
-    active: true
-  }
-] %}
+{% set activePrimaryNav = "prisons" %}
 {% set backLinkHref = "/prisons/" + prison.code + "/incentive-groups" %}
 
 {% block content %}

--- a/server/views/pages/prisons/incentiveGroups/viewIncentiveGroups.njk
+++ b/server/views/pages/prisons/incentiveGroups/viewIncentiveGroups.njk
@@ -1,23 +1,12 @@
 {% extends "partials/layout.njk" %}
 {% from "govuk/components/table/macro.njk" import govukTable %}
-{%- from "moj/components/sub-navigation/macro.njk" import mojSubNavigation -%}
 {%- from "govuk/components/tag/macro.njk" import govukTag -%}
 {% from "moj/components/page-header-actions/macro.njk" import mojPageHeaderActions %}
+{% from "components/subNavigation.njk" import subNavigation %}
 
 {% set pageHeaderTitle = prison.name %}
 {% set pageTitle = applicationName + " - Incentive level groups - " + pageHeaderTitle %}
-
-{% set primaryNavItems = [
-  {
-    text: "Home",
-    href: "/"
-  },
-  {
-    text: "Prisons",
-    href: "/prisons",
-    active: true
-  }
-] %}
+{% set activePrimaryNav = "prisons" %}
 
 {% block content %}
   {{ super() }}
@@ -42,31 +31,7 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
 
-      {{ mojSubNavigation({
-        label: "Sub navigation",
-        classes: "govuk-!-margin-top-3",
-        items: [{
-          text: "Session templates",
-          href: "/prisons/" + prison.code + "/session-templates"
-        }, {
-          text: "Excluded dates",
-          href: "/prisons/" + prison.code + "/excluded-dates"
-        }, {
-          text: "Category groups",
-          href: "/prisons/" + prison.code + "/category-groups"
-        }, {
-          text: "Incentive level groups",
-          href: "/prisons/" + prison.code + "/incentive-groups",
-          active: true
-        }, {
-          text: "Location groups",
-          href: "/prisons/" + prison.code + "/location-groups"
-        }, {
-          text: "Status",
-          href: "/prisons/" + prison.code + "/status",
-          attributes: { "data-test": "tab-status" }
-        }]
-      }) }}
+      {{ subNavigation(prison.code, "incentive-groups") }}
 
       {{ mojPageHeaderActions({
         heading: {

--- a/server/views/pages/prisons/incentiveGroups/viewSingleIncentiveGroup.njk
+++ b/server/views/pages/prisons/incentiveGroups/viewSingleIncentiveGroup.njk
@@ -7,19 +7,7 @@
 
 {% set pageHeaderTitle = incentiveGroup.name %}
 {% set pageTitle = applicationName + " - " + pageHeaderTitle %}
-
-{% set primaryNavItems = [
-  {
-    text: "Home",
-    href: "/"
-  },
-  {
-    text: "Prisons",
-    href: "/prisons",
-    active: true
-  }
-  ] %}
-
+{% set activePrimaryNav = "prisons" %}
 {% set backLinkHref = "/prisons/" + prison.code +
   ( "/session-templates/" + sessionTemplateRef if sessionTemplateRef else "/incentive-groups") %}
 

--- a/server/views/pages/prisons/locationGroups/addLocationGroup.njk
+++ b/server/views/pages/prisons/locationGroups/addLocationGroup.njk
@@ -6,18 +6,7 @@
 
 {% set pageHeaderTitle = 'Add a location group' %}
 {% set pageTitle = applicationName + " - Location groups - " + pageHeaderTitle %}
-
-{% set primaryNavItems = [
-  {
-    text: "Home",
-    href: "/"
-  },
-  {
-    text: "Prisons",
-    href: "/prisons",
-    active: true
-  }
-] %}
+{% set activePrimaryNav = "prisons" %}
 {% set backLinkHref = "/prisons/" + prison.code + "/location-groups" %}
 
 {% block content %}

--- a/server/views/pages/prisons/locationGroups/viewLocationGroups.njk
+++ b/server/views/pages/prisons/locationGroups/viewLocationGroups.njk
@@ -1,23 +1,12 @@
 {% extends "partials/layout.njk" %}
 {% from "govuk/components/table/macro.njk" import govukTable %}
-{%- from "moj/components/sub-navigation/macro.njk" import mojSubNavigation -%}
 {%- from "govuk/components/tag/macro.njk" import govukTag -%}
 {% from "moj/components/page-header-actions/macro.njk" import mojPageHeaderActions %}
+{% from "components/subNavigation.njk" import subNavigation %}
 
 {% set pageHeaderTitle = prison.name %}
 {% set pageTitle = applicationName + " - Location groups - " + pageHeaderTitle %}
-
-{% set primaryNavItems = [
-  {
-    text: "Home",
-    href: "/"
-  },
-  {
-    text: "Prisons",
-    href: "/prisons",
-    active: true
-  }
-] %}
+{% set activePrimaryNav = "prisons" %}
 
 {% block content %}
   {{ super() }}
@@ -42,31 +31,7 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
 
-      {{ mojSubNavigation({
-        label: "Sub navigation",
-        classes: "govuk-!-margin-top-3",
-        items: [{
-          text: "Session templates",
-          href: "/prisons/" + prison.code + "/session-templates"
-        }, {
-          text: "Excluded dates",
-          href: "/prisons/" + prison.code + "/excluded-dates"
-        }, {
-          text: "Category groups",
-          href: "/prisons/" + prison.code + "/category-groups"
-        }, {
-          text: "Incentive level groups",
-          href: "/prisons/" + prison.code + "/incentive-groups"
-        }, {
-          text: "Location groups",
-          href: "/prisons/" + prison.code + "/location-groups",
-          active: true
-        }, {
-          text: "Status",
-          href: "/prisons/" + prison.code + "/status",
-          attributes: { "data-test": "tab-status" }
-        }]
-      }) }}
+      {{ subNavigation(prison.code, "location-groups") }}
 
       {{ mojPageHeaderActions({
         heading: {

--- a/server/views/pages/prisons/locationGroups/viewSingleLocationGroup.njk
+++ b/server/views/pages/prisons/locationGroups/viewSingleLocationGroup.njk
@@ -7,19 +7,7 @@
 
 {% set pageHeaderTitle = locationGroup.name %}
 {% set pageTitle = applicationName + " - " + pageHeaderTitle %}
-
-{% set primaryNavItems = [
-  {
-    text: "Home",
-    href: "/"
-  },
-  {
-    text: "Prisons",
-    href: "/prisons",
-    active: true
-  }
-  ] %}
-
+{% set activePrimaryNav = "prisons" %}
 {% set backLinkHref = "/prisons/" + prison.code +
   ( "/session-templates/" + sessionTemplateRef if sessionTemplateRef else "/location-groups") %}
 

--- a/server/views/pages/prisons/prisons.njk
+++ b/server/views/pages/prisons/prisons.njk
@@ -6,18 +6,7 @@
 
 {% set pageHeaderTitle = "Supported prisons" %}
 {% set pageTitle = applicationName + " - " + pageHeaderTitle %}
-
-{% set primaryNavItems = [
-  {
-    text: "Home",
-    href: "/"
-  },
-  {
-    text: "Prisons",
-    href: "/prisons",
-    active: true
-  }
-  ] %}
+{% set activePrimaryNav = "prisons" %}
 
 {% block content %}
 {{ super() }}

--- a/server/views/pages/prisons/sessionTemplates/addSessionTemplate.njk
+++ b/server/views/pages/prisons/sessionTemplates/addSessionTemplate.njk
@@ -10,18 +10,7 @@
 
 {% set pageHeaderTitle = 'Add session template' %}
 {% set pageTitle = applicationName + " - " + pageHeaderTitle %}
-
-{% set primaryNavItems = [
-  {
-    text: "Home",
-    href: "/"
-  },
-  {
-    text: "Prisons",
-    href: "/prisons",
-    active: true
-  }
-] %}
+{% set activePrimaryNav = "prisons" %}
 {% set backLinkHref = "/prisons/" + prison.code + "/session-templates" %}
 
 {% block content %}

--- a/server/views/pages/prisons/sessionTemplates/editSingleSessionTemplate.njk
+++ b/server/views/pages/prisons/sessionTemplates/editSingleSessionTemplate.njk
@@ -10,18 +10,7 @@
 
 {% set pageHeaderTitle = 'Update session template' %}
 {% set pageTitle = applicationName + " - " + pageHeaderTitle %}
-
-{% set primaryNavItems = [
-  {
-    text: "Home",
-    href: "/"
-  },
-  {
-    text: "Prisons",
-    href: "/prisons",
-    active: true
-  }
-] %}
+{% set activePrimaryNav = "prisons" %}
 {% set backLinkHref = "/prisons/" + prison.code + "/session-templates" %}
 
 {% block content %}

--- a/server/views/pages/prisons/sessionTemplates/viewSessionTemplates.njk
+++ b/server/views/pages/prisons/sessionTemplates/viewSessionTemplates.njk
@@ -1,23 +1,12 @@
 {% extends "partials/layout.njk" %}
 {% from "govuk/components/table/macro.njk" import govukTable %}
-{%- from "moj/components/sub-navigation/macro.njk" import mojSubNavigation -%}
 {%- from "govuk/components/tag/macro.njk" import govukTag -%}
 {%- from "moj/components/identity-bar/macro.njk" import mojIdentityBar -%}
+{% from "components/subNavigation.njk" import subNavigation %}
 
 {% set pageHeaderTitle = prison.name %}
 {% set pageTitle = applicationName + " - Session templates - " + pageHeaderTitle %}
-
-{% set primaryNavItems = [
-  {
-    text: "Home",
-    href: "/"
-  },
-  {
-    text: "Prisons",
-    href: "/prisons",
-    active: true
-  }
-  ] %}
+{% set activePrimaryNav = "prisons" %}
 
 {% macro groupCountIfNotEmpty(groupArray, label) %}
   {% if groupArray | length %}
@@ -49,31 +38,7 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
 
-      {{ mojSubNavigation({
-        label: "Sub navigation",
-        classes: "govuk-!-margin-top-3",
-        items: [{
-          text: "Session templates",
-          href: "/prisons/" + prison.code + "/session-templates",
-          active: true
-        }, {
-          text: "Excluded dates",
-          href: "/prisons/" + prison.code + "/excluded-dates"
-        }, {
-          text: "Category groups",
-          href: "/prisons/" + prison.code + "/category-groups"
-        }, {
-          text: "Incentive level groups",
-          href: "/prisons/" + prison.code + "/incentive-groups"
-        }, {
-          text: "Location groups",
-          href: "/prisons/" + prison.code + "/location-groups"
-        }, {
-          text: "Status",
-          href: "/prisons/" + prison.code + "/status",
-          attributes: { "data-test": "tab-status" }
-        }]
-      }) }}
+      {{ subNavigation(prison.code, "session-templates") }}
 
       <h2 class="govuk-heading-m">Session templates</h2>
 

--- a/server/views/pages/prisons/sessionTemplates/viewSingleSessionTemplate.njk
+++ b/server/views/pages/prisons/sessionTemplates/viewSingleSessionTemplate.njk
@@ -7,19 +7,7 @@
 
 {% set pageHeaderTitle = sessionTemplate.name %}
 {% set pageTitle = applicationName + " - " + pageHeaderTitle %}
-
-{% set primaryNavItems = [
-  {
-    text: "Home",
-    href: "/"
-  },
-  {
-    text: "Prisons",
-    href: "/prisons",
-    active: true
-  }
-  ] %}
-
+{% set activePrimaryNav = "prisons" %}
 {% set backLinkHref = "/prisons/" + sessionTemplate.prisonId + "/session-templates" %}
 {% set changeStatusActionText = "activated" if sessionTemplate.active else "deactivated" %}
 

--- a/server/views/pages/prisons/status/status.njk
+++ b/server/views/pages/prisons/status/status.njk
@@ -1,22 +1,11 @@
 {% extends "partials/layout.njk" %}
-{%- from "moj/components/sub-navigation/macro.njk" import mojSubNavigation -%}
 {%- from "govuk/components/button/macro.njk" import govukButton -%}
 {%- from "govuk/components/tag/macro.njk" import govukTag -%}
+{% from "components/subNavigation.njk" import subNavigation %}
 
 {% set pageHeaderTitle = prison.name %}
 {% set pageTitle = applicationName + " - " + pageHeaderTitle %}
-
-{% set primaryNavItems = [
-  {
-    text: "Home",
-    href: "/"
-  },
-  {
-    text: "Prisons",
-    href: "/prisons",
-    active: true
-  }
-  ] %}
+{% set activePrimaryNav = "prisons" %}
 
 {% set changeStatusAction = "deactivate" if prison.active else "activate" %}
 
@@ -43,30 +32,7 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
 
-      {{ mojSubNavigation({
-        label: "Sub navigation",
-        classes: "govuk-!-margin-top-3",
-        items: [{
-          text: "Session templates",
-          href: "/prisons/" + prison.code + "/session-templates"
-        }, {
-          text: "Excluded dates",
-          href: "/prisons/" + prison.code + "/excluded-dates"
-        }, {
-          text: "Category groups",
-          href: "/prisons/" + prison.code + "/category-groups"
-        }, {
-          text: "Incentive level groups",
-          href: "/prisons/" + prison.code + "/incentive-groups"
-        }, {
-          text: "Location groups",
-          href: "/prisons/" + prison.code + "/location-groups"
-        }, {
-          text: "Status",
-          href: "/prisons/" + prison.code + "/status",
-          active: true
-        }]
-      }) }}
+      {{ subNavigation(prison.code, "status") }}
 
       <h2 class="govuk-heading-m">Change prison status</h2>
 

--- a/server/views/partials/layout.njk
+++ b/server/views/partials/layout.njk
@@ -14,10 +14,22 @@
 
 {% block header %}
   {% include "./header.njk" %}
-  {% if primaryNavItems %}
+
+  {% if activePrimaryNav %}
     {{ mojPrimaryNavigation({
       label: 'Primary navigation',
-      items: primaryNavItems
+      items: [
+      {
+        text: "Home",
+        href: "/",
+        active: activePrimaryNav === "home"
+      },
+      {
+        text: "Prisons",
+        href: "/prisons",
+        active: activePrimaryNav === "prisons"
+      }
+      ]
     }) }}
   {% endif %}
 {% endblock %}


### PR DESCRIPTION
* Remove duplication in template code by putting primary navigation in the `layout.njk` and using a macro for the sub-navigation
* Restructure integration test page classes to add a `PrisonPage` representing the common elements in `/prisons` pages (e.g. sub-nav sections). Deeper pages can extend this rather than the `Page` class.