### PR TITLE
VB-3181 Use new 'prison names' Prison Register endpoint

### DIFF
--- a/integration_tests/e2e/prisons/categoryGroups/addCategoryGroup.cy.ts
+++ b/integration_tests/e2e/prisons/categoryGroups/addCategoryGroup.cy.ts
@@ -13,7 +13,7 @@ context('Category groups - add', () => {
     cy.task('reset')
     cy.task('stubSignIn')
     cy.task('stubAuthUser')
-    cy.task('stubPrisons')
+    cy.task('stubPrisonNames')
     cy.signIn()
 
     cy.task('stubGetPrison', TestData.prisonDto())

--- a/integration_tests/e2e/prisons/categoryGroups/viewCategoryGroups.cy.ts
+++ b/integration_tests/e2e/prisons/categoryGroups/viewCategoryGroups.cy.ts
@@ -13,7 +13,7 @@ context('Category groups - list', () => {
     cy.task('reset')
     cy.task('stubSignIn')
     cy.task('stubAuthUser')
-    cy.task('stubPrisons')
+    cy.task('stubPrisonNames')
     cy.task('stubGetAllPrisons')
     cy.signIn()
   })

--- a/integration_tests/e2e/prisons/categoryGroups/viewSingleCategoryGroup.cy.ts
+++ b/integration_tests/e2e/prisons/categoryGroups/viewSingleCategoryGroup.cy.ts
@@ -12,7 +12,7 @@ context('Category groups - single', () => {
     cy.task('reset')
     cy.task('stubSignIn')
     cy.task('stubAuthUser')
-    cy.task('stubPrisons')
+    cy.task('stubPrisonNames')
     cy.signIn()
 
     cy.task('stubGetPrison', TestData.prisonDto())

--- a/integration_tests/e2e/prisons/configuration/prisonConfig.cy.ts
+++ b/integration_tests/e2e/prisons/configuration/prisonConfig.cy.ts
@@ -14,7 +14,7 @@ context('Prison configuration', () => {
     cy.task('reset')
     cy.task('stubSignIn')
     cy.task('stubAuthUser')
-    cy.task('stubPrisons')
+    cy.task('stubPrisonNames')
     cy.task('stubGetAllPrisons')
     cy.signIn()
 

--- a/integration_tests/e2e/prisons/excludedDates/excludedDates.cy.ts
+++ b/integration_tests/e2e/prisons/excludedDates/excludedDates.cy.ts
@@ -14,7 +14,7 @@ context('Excluded dates', () => {
     cy.task('reset')
     cy.task('stubSignIn')
     cy.task('stubAuthUser')
-    cy.task('stubPrisons')
+    cy.task('stubPrisonNames')
     cy.task('stubGetAllPrisons')
     cy.signIn()
   })

--- a/integration_tests/e2e/prisons/incentiveGroups/addIncentiveGroup.cy.ts
+++ b/integration_tests/e2e/prisons/incentiveGroups/addIncentiveGroup.cy.ts
@@ -12,7 +12,7 @@ context('Incentive groups - add', () => {
     cy.task('reset')
     cy.task('stubSignIn')
     cy.task('stubAuthUser')
-    cy.task('stubPrisons')
+    cy.task('stubPrisonNames')
     cy.signIn()
 
     cy.task('stubGetPrison', TestData.prisonDto())

--- a/integration_tests/e2e/prisons/incentiveGroups/viewIncentiveGroups.cy.ts
+++ b/integration_tests/e2e/prisons/incentiveGroups/viewIncentiveGroups.cy.ts
@@ -13,7 +13,7 @@ context('Incentive groups - list', () => {
     cy.task('reset')
     cy.task('stubSignIn')
     cy.task('stubAuthUser')
-    cy.task('stubPrisons')
+    cy.task('stubPrisonNames')
     cy.task('stubGetAllPrisons')
     cy.signIn()
   })

--- a/integration_tests/e2e/prisons/incentiveGroups/viewSingleIncentiveGroup.cy.ts
+++ b/integration_tests/e2e/prisons/incentiveGroups/viewSingleIncentiveGroup.cy.ts
@@ -12,7 +12,7 @@ context('Incentive groups - single', () => {
     cy.task('reset')
     cy.task('stubSignIn')
     cy.task('stubAuthUser')
-    cy.task('stubPrisons')
+    cy.task('stubPrisonNames')
     cy.task('stubGetAllPrisons')
     cy.signIn()
 

--- a/integration_tests/e2e/prisons/locationGroups/addLocationGroup.cy.ts
+++ b/integration_tests/e2e/prisons/locationGroups/addLocationGroup.cy.ts
@@ -17,7 +17,7 @@ context('Location groups - add', () => {
     cy.task('reset')
     cy.task('stubSignIn')
     cy.task('stubAuthUser')
-    cy.task('stubPrisons')
+    cy.task('stubPrisonNames')
     cy.signIn()
 
     cy.task('stubGetPrison', TestData.prisonDto())

--- a/integration_tests/e2e/prisons/locationGroups/viewLocationGroups.cy.ts
+++ b/integration_tests/e2e/prisons/locationGroups/viewLocationGroups.cy.ts
@@ -12,7 +12,7 @@ context('Location groups - list', () => {
     cy.task('reset')
     cy.task('stubSignIn')
     cy.task('stubAuthUser')
-    cy.task('stubPrisons')
+    cy.task('stubPrisonNames')
     cy.task('stubGetAllPrisons')
     cy.signIn()
   })

--- a/integration_tests/e2e/prisons/locationGroups/viewSingleLocationGroup.cy.ts
+++ b/integration_tests/e2e/prisons/locationGroups/viewSingleLocationGroup.cy.ts
@@ -16,7 +16,7 @@ context('Location groups - single', () => {
     cy.task('reset')
     cy.task('stubSignIn')
     cy.task('stubAuthUser')
-    cy.task('stubPrisons')
+    cy.task('stubPrisonNames')
     cy.signIn()
 
     cy.task('stubGetPrison', TestData.prisonDto())

--- a/integration_tests/e2e/prisons/sessionTemplates/addSessionTemplate.cy.ts
+++ b/integration_tests/e2e/prisons/sessionTemplates/addSessionTemplate.cy.ts
@@ -47,7 +47,7 @@ context('Session templates - add', () => {
     cy.task('reset')
     cy.task('stubSignIn')
     cy.task('stubAuthUser')
-    cy.task('stubPrisons')
+    cy.task('stubPrisonNames')
     cy.signIn()
 
     cy.task('stubGetPrison', TestData.prisonDto())

--- a/integration_tests/e2e/prisons/sessionTemplates/updateSessionTemplate.cy.ts
+++ b/integration_tests/e2e/prisons/sessionTemplates/updateSessionTemplate.cy.ts
@@ -12,7 +12,7 @@ context('Session templates - update', () => {
     cy.task('reset')
     cy.task('stubSignIn')
     cy.task('stubAuthUser')
-    cy.task('stubPrisons')
+    cy.task('stubPrisonNames')
     cy.signIn()
 
     cy.task('stubGetPrison', TestData.prisonDto())

--- a/integration_tests/e2e/prisons/sessionTemplates/viewSessionTemplates.cy.ts
+++ b/integration_tests/e2e/prisons/sessionTemplates/viewSessionTemplates.cy.ts
@@ -9,7 +9,7 @@ context('Session templates - list', () => {
     cy.task('reset')
     cy.task('stubSignIn')
     cy.task('stubAuthUser')
-    cy.task('stubPrisons')
+    cy.task('stubPrisonNames')
     cy.task('stubGetAllPrisons')
     cy.signIn()
   })

--- a/integration_tests/e2e/prisons/sessionTemplates/viewSingleSessionTemplate.cy.ts
+++ b/integration_tests/e2e/prisons/sessionTemplates/viewSingleSessionTemplate.cy.ts
@@ -15,7 +15,7 @@ context('Session templates - single', () => {
     cy.task('reset')
     cy.task('stubSignIn')
     cy.task('stubAuthUser')
-    cy.task('stubPrisons')
+    cy.task('stubPrisonNames')
     cy.signIn()
 
     cy.task('stubGetPrison', TestData.prisonDto())

--- a/integration_tests/e2e/prisons/sessionTemplates/viewSingleSessionTemplateDelete.cy.ts
+++ b/integration_tests/e2e/prisons/sessionTemplates/viewSingleSessionTemplateDelete.cy.ts
@@ -12,7 +12,7 @@ context('Session templates - delete', () => {
     cy.task('reset')
     cy.task('stubSignIn')
     cy.task('stubAuthUser')
-    cy.task('stubPrisons')
+    cy.task('stubPrisonNames')
     cy.signIn()
 
     cy.task('stubGetPrison', TestData.prisonDto())

--- a/integration_tests/e2e/prisons/sessionTemplates/viewSingleSessionTemplateStatus.cy.ts
+++ b/integration_tests/e2e/prisons/sessionTemplates/viewSingleSessionTemplateStatus.cy.ts
@@ -12,7 +12,7 @@ context('Session templates - status', () => {
     cy.task('reset')
     cy.task('stubSignIn')
     cy.task('stubAuthUser')
-    cy.task('stubPrisons')
+    cy.task('stubPrisonNames')
     cy.signIn()
 
     cy.task('stubGetPrison', TestData.prisonDto())

--- a/integration_tests/e2e/prisons/supportedPrisons.cy.ts
+++ b/integration_tests/e2e/prisons/supportedPrisons.cy.ts
@@ -8,7 +8,7 @@ context('Supported prisons', () => {
     cy.task('reset')
     cy.task('stubSignIn')
     cy.task('stubAuthUser')
-    cy.task('stubPrisons')
+    cy.task('stubPrisonNames')
     cy.signIn()
   })
 

--- a/integration_tests/mockApis/prisonRegister.ts
+++ b/integration_tests/mockApis/prisonRegister.ts
@@ -1,14 +1,14 @@
 import { SuperAgentRequest } from 'superagent'
 import { stubFor } from './wiremock'
 import TestData from '../../server/routes/testutils/testData'
-import { PrisonContactDetails, PrisonRegisterPrison } from '../../server/data/prisonRegisterApiTypes'
+import { PrisonContactDetails, PrisonName } from '../../server/data/prisonRegisterApiTypes'
 
 export default {
-  stubPrisons: (prisons: PrisonRegisterPrison[] = TestData.prisonRegisterPrisons()): SuperAgentRequest => {
+  stubPrisonNames: (prisons: PrisonName[] = TestData.prisonNames()): SuperAgentRequest => {
     return stubFor({
       request: {
         method: 'GET',
-        url: '/prisonRegister/prisons',
+        url: '/prisonRegister/prisons/names',
       },
       response: {
         status: 200,

--- a/server/@types/prison-register-api.d.ts
+++ b/server/@types/prison-register-api.d.ts
@@ -60,33 +60,33 @@ export interface paths {
   '/prison-maintenance/id/{prisonId}': {
     /**
      * Update specified prison details
-     * @description Updates prison information, role required is MAINTAIN_REF_DATA
+     * @description Updates prison information, role required is MAINTAIN_REF_DATA or MAINTAIN_PRISON_DATA
      */
     put: operations['updatePrison']
   }
   '/prison-maintenance/id/{prisonId}/address/{addressId}': {
     /**
      * Update specified address details
-     * @description Updates address information, role required is MAINTAIN_REF_DATA
+     * @description Updates address information, role required is MAINTAIN_REF_DATA or MAINTAIN_PRISON_DATA
      */
     put: operations['updateAddress']
     /**
      * Delete specified address for specified Prison
-     * @description Deletes address information for a Prison, role required is MAINTAIN_REF_DATA
+     * @description Deletes address information for a Prison, role required is MAINTAIN_REF_DATA or MAINTAIN_PRISON_DATA
      */
     delete: operations['deleteAddress']
   }
   '/prison-maintenance': {
     /**
      * Adds a new prison
-     * @description Adds new prison information, role required is MAINTAIN_REF_DATA
+     * @description Adds new prison information, role required is MAINTAIN_REF_DATA or MAINTAIN_PRISON_DATA
      */
     post: operations['insertPrison']
   }
   '/prison-maintenance/id/{prisonId}/address': {
     /**
      * Add Address to existing Prison
-     * @description Adds an additional Address to an existing Prison, role required is MAINTAIN_REF_DATA
+     * @description Adds an additional Address to an existing Prison, role required is MAINTAIN_REF_DATA or MAINTAIN_PRISON_DATA
      */
     post: operations['addAddress']
   }
@@ -862,7 +862,7 @@ export interface operations {
   }
   /**
    * Update specified prison details
-   * @description Updates prison information, role required is MAINTAIN_REF_DATA
+   * @description Updates prison information, role required is MAINTAIN_REF_DATA or MAINTAIN_PRISON_DATA
    */
   updatePrison: {
     parameters: {
@@ -914,7 +914,7 @@ export interface operations {
   }
   /**
    * Update specified address details
-   * @description Updates address information, role required is MAINTAIN_REF_DATA
+   * @description Updates address information, role required is MAINTAIN_REF_DATA or MAINTAIN_PRISON_DATA
    */
   updateAddress: {
     parameters: {
@@ -971,7 +971,7 @@ export interface operations {
   }
   /**
    * Delete specified address for specified Prison
-   * @description Deletes address information for a Prison, role required is MAINTAIN_REF_DATA
+   * @description Deletes address information for a Prison, role required is MAINTAIN_REF_DATA or MAINTAIN_PRISON_DATA
    */
   deleteAddress: {
     parameters: {
@@ -1015,7 +1015,7 @@ export interface operations {
   }
   /**
    * Adds a new prison
-   * @description Adds new prison information, role required is MAINTAIN_REF_DATA
+   * @description Adds new prison information, role required is MAINTAIN_REF_DATA or MAINTAIN_PRISON_DATA
    */
   insertPrison: {
     requestBody: {
@@ -1052,7 +1052,7 @@ export interface operations {
   }
   /**
    * Add Address to existing Prison
-   * @description Adds an additional Address to an existing Prison, role required is MAINTAIN_REF_DATA
+   * @description Adds an additional Address to an existing Prison, role required is MAINTAIN_REF_DATA or MAINTAIN_PRISON_DATA
    */
   addAddress: {
     parameters: {

--- a/server/@types/visit-scheduler-api.d.ts
+++ b/server/@types/visit-scheduler-api.d.ts
@@ -274,6 +274,13 @@ export interface paths {
      */
     get: operations['getSupportTypes']
   }
+  '/visits/notification/count': {
+    /**
+     * Get notification count
+     * @description Retrieve notification count by visit reference
+     */
+    get: operations['getNotificationCount']
+  }
   '/visits/notification/non-association/changed': {
     /** To notify VSiP that non association between two prisoners has changed */
     post: operations['notifyVSiPThatNonAssociationHasChanged']
@@ -297,6 +304,13 @@ export interface paths {
   '/visits/notification/visitor/restriction/changed': {
     /** To notify VSiP that a change to a visitor restriction has taken place */
     post: operations['notifyVSiPThatVisitorRestrictionChanged']
+  }
+  '/visits/notification/{prisonCode}/count': {
+    /**
+     * Get notification count for a prison
+     * @description Retrieve notification count by prison code
+     */
+    get: operations['getNotificationCountForPrison']
   }
   '/visits/search': {
     /**
@@ -693,10 +707,12 @@ export interface components {
     NonAssociationChangedNotificationDto: {
       nonAssociationPrisonerNumber: string
       prisonerNumber: string
-      /** Format: date */
-      validFromDate: string
-      /** Format: date */
-      validToDate?: string
+      /** @enum {string} */
+      type: 'NON_ASSOCIATION_CREATED' | 'NON_ASSOCIATION_UPSERT' | 'NON_ASSOCIATION_CLOSED' | 'NON_ASSOCIATION_DELETED'
+    }
+    NotificationCountDto: {
+      /** Format: int32 */
+      count: number
     }
     /** @description Visit Outcome */
     OutcomeDto: {
@@ -821,6 +837,14 @@ export interface components {
     PrisonerReleasedNotificationDto: {
       prisonCode: string
       prisonerNumber: string
+      /** @enum {string} */
+      reasonType:
+        | 'TEMPORARY_ABSENCE_RELEASE'
+        | 'RELEASED_TO_HOSPITAL'
+        | 'RELEASED'
+        | 'SENT_TO_COURT'
+        | 'TRANSFERRED'
+        | 'UNKNOWN'
     }
     PrisonerRestrictionChangeNotificationDto: {
       prisonerNumber: string
@@ -836,10 +860,16 @@ export interface components {
     RequestSessionTemplateVisitStatsDto: {
       /**
        * Format: date
-       * @description Visits from date stats
+       * @description Visits from date - for stats
        * @example 2019-11-02
        */
       visitsFromDate: string
+      /**
+       * Format: date
+       * @description Visits to date - for stats
+       * @example 2019-11-30
+       */
+      visitsToDate?: string
     }
     ReserveVisitSlotDto: {
       /** @description Username for user who actioned this request */
@@ -3083,6 +3113,32 @@ export interface operations {
       }
     }
   }
+  /**
+   * Get notification count
+   * @description Retrieve notification count by visit reference
+   */
+  getNotificationCount: {
+    responses: {
+      /** @description Retrieve notification count */
+      200: {
+        content: {
+          'application/json': components['schemas']['NotificationCountDto']
+        }
+      }
+      /** @description Unauthorized to access this endpoint */
+      401: {
+        content: {
+          'application/json': components['schemas']['ErrorResponse']
+        }
+      }
+      /** @description Incorrect permissions to access this endpoint */
+      403: {
+        content: {
+          'application/json': components['schemas']['ErrorResponse']
+        }
+      }
+    }
+  }
   /** To notify VSiP that non association between two prisoners has changed */
   notifyVSiPThatNonAssociationHasChanged: {
     requestBody: {
@@ -3694,6 +3750,41 @@ export interface operations {
         }
       }
       /** @description Incorrect permissions to notify VSiP of change */
+      403: {
+        content: {
+          'application/json': components['schemas']['ErrorResponse']
+        }
+      }
+    }
+  }
+  /**
+   * Get notification count for a prison
+   * @description Retrieve notification count by prison code
+   */
+  getNotificationCountForPrison: {
+    parameters: {
+      path: {
+        /**
+         * @description prisonCode
+         * @example CFI
+         */
+        prisonCode: string
+      }
+    }
+    responses: {
+      /** @description Retrieve notification count for a prison */
+      200: {
+        content: {
+          'application/json': components['schemas']['NotificationCountDto']
+        }
+      }
+      /** @description Unauthorized to access this endpoint */
+      401: {
+        content: {
+          'application/json': components['schemas']['ErrorResponse']
+        }
+      }
+      /** @description Incorrect permissions to access this endpoint */
       403: {
         content: {
           'application/json': components['schemas']['ErrorResponse']

--- a/server/data/prisonRegisterApiClient.test.ts
+++ b/server/data/prisonRegisterApiClient.test.ts
@@ -22,17 +22,17 @@ describe('prisonRegisterApiClient', () => {
     nock.cleanAll()
   })
 
-  describe('getPrisons', () => {
+  describe('getPrisonNames', () => {
     it('should return all prisons from the Prison Register', async () => {
-      const allPrisonRegisterPrisons = TestData.prisonRegisterPrisons()
+      const prisonNames = TestData.prisonNames()
 
       fakePrisonRegisterApi
-        .get('/prisons')
+        .get('/prisons/names')
         .matchHeader('authorization', `Bearer ${token}`)
-        .reply(200, allPrisonRegisterPrisons)
+        .reply(200, prisonNames)
 
-      const output = await prisonRegisterApiClient.getPrisons()
-      expect(output).toEqual(allPrisonRegisterPrisons)
+      const output = await prisonRegisterApiClient.getPrisonNames()
+      expect(output).toEqual(prisonNames)
     })
   })
 

--- a/server/data/prisonRegisterApiClient.ts
+++ b/server/data/prisonRegisterApiClient.ts
@@ -1,6 +1,6 @@
 import RestClient from './restClient'
 import config from '../config'
-import { PrisonContactDetails, PrisonRegisterPrison } from './prisonRegisterApiTypes'
+import { PrisonContactDetails, PrisonName } from './prisonRegisterApiTypes'
 
 export default class PrisonRegisterApiClient {
   private restClient: RestClient
@@ -9,8 +9,8 @@ export default class PrisonRegisterApiClient {
     this.restClient = new RestClient('prisonRegisterApiClient', config.apis.prisonRegister, token)
   }
 
-  async getPrisons(): Promise<PrisonRegisterPrison[]> {
-    return this.restClient.get({ path: '/prisons' })
+  async getPrisonNames(): Promise<PrisonName[]> {
+    return this.restClient.get({ path: '/prisons/names' })
   }
 
   async getPrisonContactDetails(prisonId: string): Promise<PrisonContactDetails | null> {

--- a/server/data/prisonRegisterApiTypes.ts
+++ b/server/data/prisonRegisterApiTypes.ts
@@ -1,5 +1,5 @@
 import { components } from '../@types/prison-register-api'
 
-export type PrisonRegisterPrison = Pick<components['schemas']['PrisonDto'], 'prisonId' | 'prisonName'>
+export type PrisonName = components['schemas']['PrisonNameDto']
 
 export type PrisonContactDetails = components['schemas']['ContactDetailsDto']

--- a/server/routes/testutils/testData.ts
+++ b/server/routes/testutils/testData.ts
@@ -1,5 +1,5 @@
 import { Prison } from '../../@types/visits-admin'
-import { PrisonContactDetails, PrisonRegisterPrison } from '../../data/prisonRegisterApiTypes'
+import { PrisonContactDetails, PrisonName } from '../../data/prisonRegisterApiTypes'
 import {
   CategoryGroup,
   PrisonDto,
@@ -46,14 +46,14 @@ export default class TestData {
     ] as Prison[],
   } = {}): Prison[] => prisons
 
-  // Array of partial representation of Prison register PrisonDto objects
-  static prisonRegisterPrisons = ({
+  // Array Prison Register PrisonNames
+  static prisonNames = ({
     prisons = [
       { prisonId: 'HEI', prisonName: 'Hewell (HMP)' },
       { prisonId: 'PNI', prisonName: 'Preston (HMP & YOI)' },
       { prisonId: 'WWI', prisonName: 'Wandsworth (HMP & YOI)' },
-    ] as PrisonRegisterPrison[],
-  } = {}): PrisonRegisterPrison[] => prisons
+    ] as PrisonName[],
+  } = {}): PrisonName[] => prisons
 
   static sessionTemplate = ({
     dayOfWeek = 'WEDNESDAY',

--- a/server/services/prisonService.test.ts
+++ b/server/services/prisonService.test.ts
@@ -14,21 +14,21 @@ describe('Prisons service', () => {
   const prisonRegisterApiClient = createMockPrisonRegisterApiClient()
   const visitSchedulerApiClient = createMockVisitSchedulerApiClient()
 
-  let prisonsService: PrisonService
+  let prisonService: PrisonService
 
   const PrisonRegisterApiClientFactory = jest.fn()
   const VisitSchedulerApiClientFactory = jest.fn()
 
   const prisonDto = TestData.prisonDto()
   const prison = TestData.prison()
-  const prisonRegisterPrisons = TestData.prisonRegisterPrisons()
+  const prisonNames = TestData.prisonNames()
 
   beforeEach(() => {
     PrisonRegisterApiClientFactory.mockReturnValue(prisonRegisterApiClient)
     VisitSchedulerApiClientFactory.mockReturnValue(visitSchedulerApiClient)
-    prisonsService = new PrisonService(VisitSchedulerApiClientFactory, PrisonRegisterApiClientFactory, hmppsAuthClient)
+    prisonService = new PrisonService(VisitSchedulerApiClientFactory, PrisonRegisterApiClientFactory, hmppsAuthClient)
 
-    prisonRegisterApiClient.getPrisons.mockResolvedValue(prisonRegisterPrisons)
+    prisonRegisterApiClient.getPrisonNames.mockResolvedValue(prisonNames)
     hmppsAuthClient.getSystemClientToken.mockResolvedValue(token)
   })
 
@@ -39,7 +39,7 @@ describe('Prisons service', () => {
   describe('getPrison', () => {
     it('should return a Prison', async () => {
       visitSchedulerApiClient.getPrison.mockResolvedValue(prisonDto)
-      const results = await prisonsService.getPrison('user', prisonDto.code)
+      const results = await prisonService.getPrison('user', prisonDto.code)
 
       expect(results).toStrictEqual(prison)
     })
@@ -49,7 +49,7 @@ describe('Prisons service', () => {
       const prisonNotInRegister = TestData.prison({ ...prisonDtoNotInRegister, name: 'UNKNOWN' })
 
       visitSchedulerApiClient.getPrison.mockResolvedValue(prisonDtoNotInRegister)
-      const results = await prisonsService.getPrison('user', prisonDtoNotInRegister.code)
+      const results = await prisonService.getPrison('user', prisonDtoNotInRegister.code)
 
       expect(results).toStrictEqual(prisonNotInRegister)
     })
@@ -62,7 +62,7 @@ describe('Prisons service', () => {
     it('should return an array of all supported Prisons', async () => {
       visitSchedulerApiClient.getAllPrisons.mockResolvedValue(allPrisonDtos)
 
-      const results = await prisonsService.getAllPrisons('user')
+      const results = await prisonService.getAllPrisons('user')
 
       expect(results).toStrictEqual(allPrisons)
     })
@@ -71,7 +71,7 @@ describe('Prisons service', () => {
       const unsortedPrisonDtos = [allPrisonDtos[2], allPrisonDtos[0], allPrisonDtos[1]]
       visitSchedulerApiClient.getAllPrisons.mockResolvedValue(unsortedPrisonDtos)
 
-      const results = await prisonsService.getAllPrisons('user')
+      const results = await prisonService.getAllPrisons('user')
 
       expect(results).toStrictEqual(allPrisons)
     })
@@ -96,7 +96,7 @@ describe('Prisons service', () => {
       it('should return prison SOCIAL_VISIT contact details from the Prison Register', async () => {
         prisonRegisterApiClient.getPrisonContactDetails.mockResolvedValue(prisonContactDetails)
 
-        const results = await prisonsService.getPrisonContactDetails('user', prison.code)
+        const results = await prisonService.getPrisonContactDetails('user', prison.code)
         expect(results).toStrictEqual(prisonContactDetails)
         expect(prisonRegisterApiClient.getPrisonContactDetails).toHaveBeenCalledWith('HEI')
       })
@@ -106,7 +106,7 @@ describe('Prisons service', () => {
       it('should create prison SOCIAL_VISIT contact details for selected prison', async () => {
         prisonRegisterApiClient.createPrisonContactDetails.mockResolvedValue(prisonContactDetails)
 
-        const results = await prisonsService.createPrisonContactDetails('user', prison.code, prisonContactDetails)
+        const results = await prisonService.createPrisonContactDetails('user', prison.code, prisonContactDetails)
         expect(results).toStrictEqual(prisonContactDetails)
         expect(prisonRegisterApiClient.createPrisonContactDetails).toHaveBeenCalledWith('HEI', prisonContactDetails)
       })
@@ -114,7 +114,7 @@ describe('Prisons service', () => {
       it('should create prison SOCIAL_VISIT contact details for selected prison - with empty values sent as NULL', async () => {
         prisonRegisterApiClient.createPrisonContactDetails.mockResolvedValue(prisonContactDetailsNulls)
 
-        const results = await prisonsService.createPrisonContactDetails(
+        const results = await prisonService.createPrisonContactDetails(
           'user',
           prison.code,
           prisonContactDetailsEmptyStrings,
@@ -129,7 +129,7 @@ describe('Prisons service', () => {
 
     describe('deletePrisonContactDetails', () => {
       it('should delete prison SOCIAL_VISIT contact details for selected prison', async () => {
-        await prisonsService.deletePrisonContactDetails('user', prison.code)
+        await prisonService.deletePrisonContactDetails('user', prison.code)
         expect(prisonRegisterApiClient.deletePrisonContactDetails).toHaveBeenCalledWith('HEI')
       })
     })
@@ -138,7 +138,7 @@ describe('Prisons service', () => {
       it('should update prison SOCIAL_VISIT contact details for selected prison', async () => {
         prisonRegisterApiClient.updatePrisonContactDetails.mockResolvedValue(prisonContactDetails)
 
-        const results = await prisonsService.updatePrisonContactDetails('user', prison.code, prisonContactDetails)
+        const results = await prisonService.updatePrisonContactDetails('user', prison.code, prisonContactDetails)
         expect(results).toStrictEqual(prisonContactDetails)
         expect(prisonRegisterApiClient.updatePrisonContactDetails).toHaveBeenCalledWith('HEI', prisonContactDetails)
       })
@@ -146,7 +146,7 @@ describe('Prisons service', () => {
       it('should update prison SOCIAL_VISIT contact details for selected prison - with empty values sent as NULL', async () => {
         prisonRegisterApiClient.updatePrisonContactDetails.mockResolvedValue(prisonContactDetailsNulls)
 
-        const results = await prisonsService.updatePrisonContactDetails(
+        const results = await prisonService.updatePrisonContactDetails(
           'user',
           prison.code,
           prisonContactDetailsEmptyStrings,
@@ -164,43 +164,32 @@ describe('Prisons service', () => {
     it('should add prison to supported prisons', async () => {
       const newPrison = TestData.prisonDto({ active: false })
 
-      await prisonsService.createPrison('user', prisonDto.code)
+      await prisonService.createPrison('user', prisonDto.code)
       expect(visitSchedulerApiClient.createPrison).toHaveBeenCalledWith(newPrison)
     })
   })
 
   describe('getPrisonName', () => {
     it('should return prison name for given prison ID', async () => {
-      const results = await prisonsService.getPrisonName('user', prisonRegisterPrisons[0].prisonId)
-      expect(results).toBe(prisonRegisterPrisons[0].prisonName)
+      const results = await prisonService.getPrisonName('user', prisonNames[0].prisonId)
+      expect(results).toBe(prisonNames[0].prisonName)
     })
 
     it('should throw a 404 error if no name found for prison ID', async () => {
-      await expect(prisonsService.getPrisonName('user', 'XYZ')).rejects.toThrow(NotFound)
-    })
-  })
-
-  describe('getPrisonNames', () => {
-    it('should return object with all prisonId / prisonNames as key / value', async () => {
-      const results = await prisonsService.getPrisonNames('user')
-      expect(results).toStrictEqual({
-        [prisonRegisterPrisons[0].prisonId]: prisonRegisterPrisons[0].prisonName,
-        [prisonRegisterPrisons[1].prisonId]: prisonRegisterPrisons[1].prisonName,
-        [prisonRegisterPrisons[2].prisonId]: prisonRegisterPrisons[2].prisonName,
-      })
+      await expect(prisonService.getPrisonName('user', 'XYZ')).rejects.toThrow(NotFound)
     })
   })
 
   describe('activatePrison', () => {
     it('should change prison to active', async () => {
-      await prisonsService.activatePrison('user', prisonDto.code)
+      await prisonService.activatePrison('user', prisonDto.code)
       expect(visitSchedulerApiClient.activatePrison).toHaveBeenCalledWith('HEI')
     })
   })
 
   describe('deactivatePrison', () => {
     it('should change prison to inactive', async () => {
-      await prisonsService.deactivatePrison('user', prisonDto.code)
+      await prisonService.deactivatePrison('user', prisonDto.code)
       expect(visitSchedulerApiClient.deactivatePrison).toHaveBeenCalledWith('HEI')
     })
   })
@@ -208,7 +197,7 @@ describe('Prisons service', () => {
   describe('addExcludeDate', () => {
     it('should add an exclude date to a prison', async () => {
       const excludeDate = '2023-07-06'
-      await prisonsService.addExcludeDate('user', prisonDto.code, excludeDate)
+      await prisonService.addExcludeDate('user', prisonDto.code, excludeDate)
       expect(visitSchedulerApiClient.addExcludeDate).toHaveBeenCalledWith('HEI', excludeDate)
     })
   })
@@ -216,7 +205,7 @@ describe('Prisons service', () => {
   describe('removeExcludeDate', () => {
     it('should remove an exclude date to a prison', async () => {
       const excludeDate = '2023-07-06'
-      await prisonsService.removeExcludeDate('user', prisonDto.code, excludeDate)
+      await prisonService.removeExcludeDate('user', prisonDto.code, excludeDate)
       expect(visitSchedulerApiClient.removeExcludeDate).toHaveBeenCalledWith('HEI', excludeDate)
     })
   })
@@ -225,12 +214,12 @@ describe('Prisons service', () => {
     it('should call Prison register API to get all prison names and then use internal cache for subsequent calls', async () => {
       const results = []
 
-      results[0] = await prisonsService.getPrisonName('user', prisonRegisterPrisons[0].prisonId)
-      results[1] = await prisonsService.getPrisonName('user', prisonRegisterPrisons[0].prisonId)
+      results[0] = await prisonService.getPrisonName('user', prisonNames[0].prisonId)
+      results[1] = await prisonService.getPrisonName('user', prisonNames[0].prisonId)
 
-      expect(results[0]).toEqual(prisonRegisterPrisons[0].prisonName)
-      expect(results[1]).toEqual(prisonRegisterPrisons[0].prisonName)
-      expect(prisonRegisterApiClient.getPrisons).toHaveBeenCalledTimes(1)
+      expect(results[0]).toEqual(prisonNames[0].prisonName)
+      expect(results[1]).toEqual(prisonNames[0].prisonName)
+      expect(prisonRegisterApiClient.getPrisonNames).toHaveBeenCalledTimes(1)
     })
 
     it('should refresh internal cache of all prisons after 24 hours', async () => {
@@ -239,15 +228,15 @@ describe('Prisons service', () => {
       const A_DAY_IN_MS = 24 * 60 * 60 * 1000
       const results = []
 
-      results[0] = await prisonsService.getPrisonName('user', prisonRegisterPrisons[0].prisonId)
-      results[1] = await prisonsService.getPrisonName('user', prisonRegisterPrisons[0].prisonId)
+      results[0] = await prisonService.getPrisonName('user', prisonNames[0].prisonId)
+      results[1] = await prisonService.getPrisonName('user', prisonNames[0].prisonId)
       jest.advanceTimersByTime(A_DAY_IN_MS)
-      results[2] = await prisonsService.getPrisonName('user', prisonRegisterPrisons[0].prisonId)
+      results[2] = await prisonService.getPrisonName('user', prisonNames[0].prisonId)
 
-      expect(results[0]).toEqual(prisonRegisterPrisons[0].prisonName)
-      expect(results[1]).toEqual(prisonRegisterPrisons[0].prisonName)
-      expect(results[2]).toEqual(prisonRegisterPrisons[0].prisonName)
-      expect(prisonRegisterApiClient.getPrisons).toHaveBeenCalledTimes(2)
+      expect(results[0]).toEqual(prisonNames[0].prisonName)
+      expect(results[1]).toEqual(prisonNames[0].prisonName)
+      expect(results[2]).toEqual(prisonNames[0].prisonName)
+      expect(prisonRegisterApiClient.getPrisonNames).toHaveBeenCalledTimes(2)
 
       jest.useRealTimers()
     })


### PR DESCRIPTION
Use new endpoint that just returns prison code/name (`/prisons/names`) in place of the existing `/prisons` that returns a lot of unnecessary data. The list of names is still cached within the `PrisonService`.

Most of the changes are actually just updating variable names to be more appropriate.