### PR TITLE
VB-3191 Switch to hmpps-manage-users-api 

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ REDIS_HOST=localhost
 HMPPS_AUTH_URL=https://sign-in-dev.hmpps.service.justice.gov.uk/auth
 HMPPS_AUTH_EXTERNAL_URL=https://sign-in-dev.hmpps.service.justice.gov.uk/auth
 NOMIS_AUTH_URL=https://sign-in-dev.hmpps.service.justice.gov.uk/auth
+MANAGE_USERS_API_URL=https://manage-users-api-dev.hmpps.service.justice.gov.uk
 NODE_ENV=development
 
 # Use credentials from the dev namespace for API and SYSTEM client

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig } from 'cypress'
 import { resetStubs } from './integration_tests/mockApis/wiremock'
 import auth from './integration_tests/mockApis/auth'
+import manageUsersApi from './integration_tests/mockApis/manageUsersApi'
 import tokenVerification from './integration_tests/mockApis/tokenVerification'
 import prisonRegister from './integration_tests/mockApis/prisonRegister'
 import categoryGroups from './integration_tests/mockApis/visitScheduler/categoryGroups'
@@ -29,6 +30,7 @@ export default defineConfig({
       on('task', {
         reset: resetStubs,
         ...auth,
+        ...manageUsersApi,
         ...tokenVerification,
 
         ...prisonRegister,

--- a/feature.env
+++ b/feature.env
@@ -1,5 +1,6 @@
 PORT=3007
 HMPPS_AUTH_URL=http://localhost:9091/auth
+MANAGE_USERS_API_URL=http://localhost:9091/manage-users-api
 TOKEN_VERIFICATION_API_URL=http://localhost:9091/verification
 TOKEN_VERIFICATION_ENABLED=true
 NODE_ENV=development

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -10,6 +10,7 @@ generic-service:
   env:
     INGRESS_URL: "https://visits-internal-admin-dev.prison.service.justice.gov.uk"
     HMPPS_AUTH_URL: "https://sign-in-dev.hmpps.service.justice.gov.uk/auth"
+    MANAGE_USERS_API_URL: "https://manage-users-api-dev.hmpps.service.justice.gov.uk"
     TOKEN_VERIFICATION_API_URL: "https://token-verification-api-dev.prison.service.justice.gov.uk"
     PRISON_REGISTER_API_URL: "https://prison-register-dev.hmpps.service.justice.gov.uk"
     VISIT_SCHEDULER_API_URL: "https://visit-scheduler-dev.prison.service.justice.gov.uk"

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -10,6 +10,7 @@ generic-service:
   env:
     INGRESS_URL: "https://visits-internal-admin-preprod.prison.service.justice.gov.uk"
     HMPPS_AUTH_URL: "https://sign-in-preprod.hmpps.service.justice.gov.uk/auth"
+    MANAGE_USERS_API_URL: "https://manage-users-api-preprod.hmpps.service.justice.gov.uk"
     TOKEN_VERIFICATION_API_URL: "https://token-verification-api-preprod.prison.service.justice.gov.uk"
     PRISON_REGISTER_API_URL: "https://prison-register-preprod.hmpps.service.justice.gov.uk"
     VISIT_SCHEDULER_API_URL: "https://visit-scheduler-preprod.prison.service.justice.gov.uk"

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -10,6 +10,7 @@ generic-service:
   env:
     INGRESS_URL: "https://visits-internal-admin.prison.service.justice.gov.uk"
     HMPPS_AUTH_URL: "https://sign-in.hmpps.service.justice.gov.uk/auth"
+    MANAGE_USERS_API_URL: "https://manage-users-api.hmpps.service.justice.gov.uk"
     TOKEN_VERIFICATION_API_URL: "https://token-verification-api.prison.service.justice.gov.uk"
     PRISON_REGISTER_API_URL: "https://prison-register.hmpps.service.justice.gov.uk"
     VISIT_SCHEDULER_API_URL: "https://visit-scheduler.prison.service.justice.gov.uk"

--- a/helm_deploy/values-staging.yaml
+++ b/helm_deploy/values-staging.yaml
@@ -10,6 +10,7 @@ generic-service:
   env:
     INGRESS_URL: "https://visits-internal-admin-staging.prison.service.justice.gov.uk"
     HMPPS_AUTH_URL: "https://sign-in-dev.hmpps.service.justice.gov.uk/auth"
+    MANAGE_USERS_API_URL: "https://manage-users-api-dev.hmpps.service.justice.gov.uk"
     TOKEN_VERIFICATION_API_URL: "https://token-verification-api-dev.prison.service.justice.gov.uk"
     PRISON_REGISTER_API_URL: "https://prison-register-dev.hmpps.service.justice.gov.uk"
     VISIT_SCHEDULER_API_URL: "https://visit-scheduler-staging.prison.service.justice.gov.uk"

--- a/integration_tests/e2e/health.cy.ts
+++ b/integration_tests/e2e/health.cy.ts
@@ -3,6 +3,7 @@ context('Healthcheck', () => {
     beforeEach(() => {
       cy.task('reset')
       cy.task('stubAuthPing')
+      cy.task('stubManageUsersPing')
       cy.task('stubTokenVerificationPing')
     })
 

--- a/integration_tests/e2e/home.cy.ts
+++ b/integration_tests/e2e/home.cy.ts
@@ -5,7 +5,7 @@ context('Home page', () => {
   beforeEach(() => {
     cy.task('reset')
     cy.task('stubSignIn')
-    cy.task('stubAuthUser')
+    cy.task('stubManageUser')
     cy.signIn()
   })
 

--- a/integration_tests/e2e/login.cy.ts
+++ b/integration_tests/e2e/login.cy.ts
@@ -8,7 +8,7 @@ context('SignIn', () => {
   beforeEach(() => {
     cy.task('reset')
     cy.task('stubSignIn')
-    cy.task('stubAuthUser')
+    cy.task('stubManageUser')
   })
 
   it('Unauthenticated user directed to auth', () => {
@@ -61,7 +61,7 @@ context('SignIn', () => {
     cy.request('/').its('body').should('contain', 'Sign in')
 
     cy.task('stubVerifyToken', true)
-    cy.task('stubAuthUser', 'bobby brown')
+    cy.task('stubManageUser', 'bobby brown')
     cy.signIn()
 
     indexPage.headerUserName().contains('B. Brown')

--- a/integration_tests/e2e/prisons/categoryGroups/addCategoryGroup.cy.ts
+++ b/integration_tests/e2e/prisons/categoryGroups/addCategoryGroup.cy.ts
@@ -12,7 +12,7 @@ context('Category groups - add', () => {
   beforeEach(() => {
     cy.task('reset')
     cy.task('stubSignIn')
-    cy.task('stubAuthUser')
+    cy.task('stubManageUser')
     cy.task('stubPrisonNames')
     cy.signIn()
 

--- a/integration_tests/e2e/prisons/categoryGroups/viewCategoryGroups.cy.ts
+++ b/integration_tests/e2e/prisons/categoryGroups/viewCategoryGroups.cy.ts
@@ -12,7 +12,7 @@ context('Category groups - list', () => {
   beforeEach(() => {
     cy.task('reset')
     cy.task('stubSignIn')
-    cy.task('stubAuthUser')
+    cy.task('stubManageUser')
     cy.task('stubPrisonNames')
     cy.task('stubGetAllPrisons')
     cy.signIn()

--- a/integration_tests/e2e/prisons/categoryGroups/viewSingleCategoryGroup.cy.ts
+++ b/integration_tests/e2e/prisons/categoryGroups/viewSingleCategoryGroup.cy.ts
@@ -11,7 +11,7 @@ context('Category groups - single', () => {
   beforeEach(() => {
     cy.task('reset')
     cy.task('stubSignIn')
-    cy.task('stubAuthUser')
+    cy.task('stubManageUser')
     cy.task('stubPrisonNames')
     cy.signIn()
 

--- a/integration_tests/e2e/prisons/configuration/prisonConfig.cy.ts
+++ b/integration_tests/e2e/prisons/configuration/prisonConfig.cy.ts
@@ -14,7 +14,7 @@ context('Prison configuration', () => {
   beforeEach(() => {
     cy.task('reset')
     cy.task('stubSignIn')
-    cy.task('stubAuthUser')
+    cy.task('stubManageUser')
     cy.task('stubPrisonNames')
     cy.task('stubGetAllPrisons')
     cy.signIn()

--- a/integration_tests/e2e/prisons/excludedDates/excludedDates.cy.ts
+++ b/integration_tests/e2e/prisons/excludedDates/excludedDates.cy.ts
@@ -13,7 +13,7 @@ context('Excluded dates', () => {
   beforeEach(() => {
     cy.task('reset')
     cy.task('stubSignIn')
-    cy.task('stubAuthUser')
+    cy.task('stubManageUser')
     cy.task('stubPrisonNames')
     cy.task('stubGetAllPrisons')
     cy.signIn()

--- a/integration_tests/e2e/prisons/incentiveGroups/addIncentiveGroup.cy.ts
+++ b/integration_tests/e2e/prisons/incentiveGroups/addIncentiveGroup.cy.ts
@@ -11,7 +11,7 @@ context('Incentive groups - add', () => {
   beforeEach(() => {
     cy.task('reset')
     cy.task('stubSignIn')
-    cy.task('stubAuthUser')
+    cy.task('stubManageUser')
     cy.task('stubPrisonNames')
     cy.signIn()
 

--- a/integration_tests/e2e/prisons/incentiveGroups/viewIncentiveGroups.cy.ts
+++ b/integration_tests/e2e/prisons/incentiveGroups/viewIncentiveGroups.cy.ts
@@ -12,7 +12,7 @@ context('Incentive groups - list', () => {
   beforeEach(() => {
     cy.task('reset')
     cy.task('stubSignIn')
-    cy.task('stubAuthUser')
+    cy.task('stubManageUser')
     cy.task('stubPrisonNames')
     cy.task('stubGetAllPrisons')
     cy.signIn()

--- a/integration_tests/e2e/prisons/incentiveGroups/viewSingleIncentiveGroup.cy.ts
+++ b/integration_tests/e2e/prisons/incentiveGroups/viewSingleIncentiveGroup.cy.ts
@@ -11,7 +11,7 @@ context('Incentive groups - single', () => {
   beforeEach(() => {
     cy.task('reset')
     cy.task('stubSignIn')
-    cy.task('stubAuthUser')
+    cy.task('stubManageUser')
     cy.task('stubPrisonNames')
     cy.task('stubGetAllPrisons')
     cy.signIn()

--- a/integration_tests/e2e/prisons/locationGroups/addLocationGroup.cy.ts
+++ b/integration_tests/e2e/prisons/locationGroups/addLocationGroup.cy.ts
@@ -16,7 +16,7 @@ context('Location groups - add', () => {
   beforeEach(() => {
     cy.task('reset')
     cy.task('stubSignIn')
-    cy.task('stubAuthUser')
+    cy.task('stubManageUser')
     cy.task('stubPrisonNames')
     cy.signIn()
 

--- a/integration_tests/e2e/prisons/locationGroups/viewLocationGroups.cy.ts
+++ b/integration_tests/e2e/prisons/locationGroups/viewLocationGroups.cy.ts
@@ -11,7 +11,7 @@ context('Location groups - list', () => {
   beforeEach(() => {
     cy.task('reset')
     cy.task('stubSignIn')
-    cy.task('stubAuthUser')
+    cy.task('stubManageUser')
     cy.task('stubPrisonNames')
     cy.task('stubGetAllPrisons')
     cy.signIn()

--- a/integration_tests/e2e/prisons/locationGroups/viewSingleLocationGroup.cy.ts
+++ b/integration_tests/e2e/prisons/locationGroups/viewSingleLocationGroup.cy.ts
@@ -15,7 +15,7 @@ context('Location groups - single', () => {
   beforeEach(() => {
     cy.task('reset')
     cy.task('stubSignIn')
-    cy.task('stubAuthUser')
+    cy.task('stubManageUser')
     cy.task('stubPrisonNames')
     cy.signIn()
 

--- a/integration_tests/e2e/prisons/sessionTemplates/addSessionTemplate.cy.ts
+++ b/integration_tests/e2e/prisons/sessionTemplates/addSessionTemplate.cy.ts
@@ -46,7 +46,7 @@ context('Session templates - add', () => {
   beforeEach(() => {
     cy.task('reset')
     cy.task('stubSignIn')
-    cy.task('stubAuthUser')
+    cy.task('stubManageUser')
     cy.task('stubPrisonNames')
     cy.signIn()
 

--- a/integration_tests/e2e/prisons/sessionTemplates/updateSessionTemplate.cy.ts
+++ b/integration_tests/e2e/prisons/sessionTemplates/updateSessionTemplate.cy.ts
@@ -11,7 +11,7 @@ context('Session templates - update', () => {
   beforeEach(() => {
     cy.task('reset')
     cy.task('stubSignIn')
-    cy.task('stubAuthUser')
+    cy.task('stubManageUser')
     cy.task('stubPrisonNames')
     cy.signIn()
 

--- a/integration_tests/e2e/prisons/sessionTemplates/viewSessionTemplates.cy.ts
+++ b/integration_tests/e2e/prisons/sessionTemplates/viewSessionTemplates.cy.ts
@@ -8,7 +8,7 @@ context('Session templates - list', () => {
   beforeEach(() => {
     cy.task('reset')
     cy.task('stubSignIn')
-    cy.task('stubAuthUser')
+    cy.task('stubManageUser')
     cy.task('stubPrisonNames')
     cy.task('stubGetAllPrisons')
     cy.signIn()

--- a/integration_tests/e2e/prisons/sessionTemplates/viewSingleSessionTemplate.cy.ts
+++ b/integration_tests/e2e/prisons/sessionTemplates/viewSingleSessionTemplate.cy.ts
@@ -14,7 +14,7 @@ context('Session templates - single', () => {
   beforeEach(() => {
     cy.task('reset')
     cy.task('stubSignIn')
-    cy.task('stubAuthUser')
+    cy.task('stubManageUser')
     cy.task('stubPrisonNames')
     cy.signIn()
 

--- a/integration_tests/e2e/prisons/sessionTemplates/viewSingleSessionTemplateDelete.cy.ts
+++ b/integration_tests/e2e/prisons/sessionTemplates/viewSingleSessionTemplateDelete.cy.ts
@@ -11,7 +11,7 @@ context('Session templates - delete', () => {
   beforeEach(() => {
     cy.task('reset')
     cy.task('stubSignIn')
-    cy.task('stubAuthUser')
+    cy.task('stubManageUser')
     cy.task('stubPrisonNames')
     cy.signIn()
 

--- a/integration_tests/e2e/prisons/sessionTemplates/viewSingleSessionTemplateStatus.cy.ts
+++ b/integration_tests/e2e/prisons/sessionTemplates/viewSingleSessionTemplateStatus.cy.ts
@@ -11,7 +11,7 @@ context('Session templates - status', () => {
   beforeEach(() => {
     cy.task('reset')
     cy.task('stubSignIn')
-    cy.task('stubAuthUser')
+    cy.task('stubManageUser')
     cy.task('stubPrisonNames')
     cy.signIn()
 

--- a/integration_tests/e2e/prisons/supportedPrisons.cy.ts
+++ b/integration_tests/e2e/prisons/supportedPrisons.cy.ts
@@ -7,7 +7,7 @@ context('Supported prisons', () => {
   beforeEach(() => {
     cy.task('reset')
     cy.task('stubSignIn')
-    cy.task('stubAuthUser')
+    cy.task('stubManageUser')
     cy.task('stubPrisonNames')
     cy.signIn()
   })

--- a/integration_tests/mockApis/auth.ts
+++ b/integration_tests/mockApis/auth.ts
@@ -118,45 +118,9 @@ const token = (role: string) =>
     },
   })
 
-const stubUser = (name: string) =>
-  stubFor({
-    request: {
-      method: 'GET',
-      urlPattern: '/auth/api/user/me',
-    },
-    response: {
-      status: 200,
-      headers: {
-        'Content-Type': 'application/json;charset=UTF-8',
-      },
-      jsonBody: {
-        staffId: 231232,
-        username: 'USER1',
-        active: true,
-        name,
-      },
-    },
-  })
-
-const stubUserRoles = () =>
-  stubFor({
-    request: {
-      method: 'GET',
-      urlPattern: '/auth/api/user/me/roles',
-    },
-    response: {
-      status: 200,
-      headers: {
-        'Content-Type': 'application/json;charset=UTF-8',
-      },
-      jsonBody: [{ roleCode: 'ROLE_PRISON_VISITS_ADMIN' }],
-    },
-  })
-
 export default {
   getSignInUrl,
   stubAuthPing: ping,
   stubSignIn: (role: string): Promise<[Response, Response, Response, Response, Response, Response]> =>
     Promise.all([favicon(), redirect(), signOut(), manageDetails(), token(role), tokenVerification.stubVerifyToken()]),
-  stubAuthUser: (name = 'john smith'): Promise<[Response, Response]> => Promise.all([stubUser(name), stubUserRoles()]),
 }

--- a/integration_tests/mockApis/manageUsersApi.ts
+++ b/integration_tests/mockApis/manageUsersApi.ts
@@ -1,0 +1,43 @@
+import { Response } from 'superagent'
+
+import { stubFor } from './wiremock'
+
+const stubUser = (name: string) =>
+  stubFor({
+    request: {
+      method: 'GET',
+      urlPattern: '/manage-users-api/users/me',
+    },
+    response: {
+      status: 200,
+      headers: {
+        'Content-Type': 'application/json;charset=UTF-8',
+      },
+      jsonBody: {
+        staffId: 231232,
+        username: 'USER1',
+        active: true,
+        name,
+      },
+    },
+  })
+
+const stubUserRoles = () =>
+  stubFor({
+    request: {
+      method: 'GET',
+      urlPattern: '/manage-users-api/users/me/roles',
+    },
+    response: {
+      status: 200,
+      headers: {
+        'Content-Type': 'application/json;charset=UTF-8',
+      },
+      jsonBody: [{ roleCode: 'SOME_USER_ROLE' }],
+    },
+  })
+
+export default {
+  stubManageUser: (name = 'john smith'): Promise<[Response, Response]> =>
+    Promise.all([stubUser(name), stubUserRoles()]),
+}

--- a/integration_tests/mockApis/manageUsersApi.ts
+++ b/integration_tests/mockApis/manageUsersApi.ts
@@ -37,7 +37,19 @@ const stubUserRoles = () =>
     },
   })
 
+const ping = () =>
+  stubFor({
+    request: {
+      method: 'GET',
+      urlPattern: '/manage-users-api/health/ping',
+    },
+    response: {
+      status: 200,
+    },
+  })
+
 export default {
   stubManageUser: (name = 'john smith'): Promise<[Response, Response]> =>
     Promise.all([stubUser(name), stubUserRoles()]),
+  stubManageUsersPing: ping,
 }

--- a/server/config.ts
+++ b/server/config.ts
@@ -59,6 +59,14 @@ export default {
       systemClientId: get('SYSTEM_CLIENT_ID', 'clientid', requiredInProduction),
       systemClientSecret: get('SYSTEM_CLIENT_SECRET', 'clientsecret', requiredInProduction),
     },
+    manageUsersApi: {
+      url: get('MANAGE_USERS_API_URL', 'http://localhost:9091', requiredInProduction),
+      timeout: {
+        response: Number(get('MANAGE_USERS_API_TIMEOUT_RESPONSE', 10000)),
+        deadline: Number(get('MANAGE_USERS_API_TIMEOUT_DEADLINE', 10000)),
+      },
+      agent: new AgentConfig(Number(get('MANAGE_USERS_API_TIMEOUT_RESPONSE', 10000))),
+    },
     tokenVerification: {
       url: get('TOKEN_VERIFICATION_API_URL', 'http://localhost:8100', requiredInProduction),
       timeout: {

--- a/server/data/hmppsAuthClient.test.ts
+++ b/server/data/hmppsAuthClient.test.ts
@@ -25,32 +25,6 @@ describe('hmppsAuthClient', () => {
     nock.cleanAll()
   })
 
-  describe('getUser', () => {
-    it('should return data from api', async () => {
-      const response = { data: 'data' }
-
-      fakeHmppsAuthApi
-        .get('/api/user/me')
-        .matchHeader('authorization', `Bearer ${token.access_token}`)
-        .reply(200, response)
-
-      const output = await hmppsAuthClient.getUser(token.access_token)
-      expect(output).toEqual(response)
-    })
-  })
-
-  describe('getUserRoles', () => {
-    it('should return data from api', async () => {
-      fakeHmppsAuthApi
-        .get('/api/user/me/roles')
-        .matchHeader('authorization', `Bearer ${token.access_token}`)
-        .reply(200, [{ roleCode: 'role1' }, { roleCode: 'role2' }])
-
-      const output = await hmppsAuthClient.getUserRoles(token.access_token)
-      expect(output).toEqual(['role1', 'role2'])
-    })
-  })
-
   describe('getSystemClientToken', () => {
     it('should instantiate the redis client', async () => {
       tokenStore.getToken.mockResolvedValue(token.access_token)

--- a/server/data/hmppsAuthClient.ts
+++ b/server/data/hmppsAuthClient.ts
@@ -31,31 +31,11 @@ function getSystemClientTokenFromHmppsAuth(username?: string): Promise<superagen
     .timeout(timeoutSpec)
 }
 
-export interface User {
-  name: string
-  activeCaseLoadId: string
-}
-
-export interface UserRole {
-  roleCode: string
-}
-
 export default class HmppsAuthClient {
   constructor(private readonly tokenStore: TokenStore) {}
 
   private static restClient(token: string): RestClient {
     return new RestClient('HMPPS Auth Client', config.apis.hmppsAuth, token)
-  }
-
-  getUser(token: string): Promise<User> {
-    logger.info(`Getting user details: calling HMPPS Auth`)
-    return HmppsAuthClient.restClient(token).get({ path: '/api/user/me' }) as Promise<User>
-  }
-
-  getUserRoles(token: string): Promise<string[]> {
-    return HmppsAuthClient.restClient(token)
-      .get({ path: '/api/user/me/roles' })
-      .then(roles => (<UserRole[]>roles).map(role => role.roleCode))
   }
 
   async getSystemClientToken(username?: string): Promise<string> {

--- a/server/data/index.ts
+++ b/server/data/index.ts
@@ -11,6 +11,7 @@ initialiseAppInsights()
 buildAppInsightsClient(applicationInfo)
 
 import HmppsAuthClient from './hmppsAuthClient'
+import ManageUsersApiClient from './manageUsersApiClient'
 import { createRedisClient } from './redisClient'
 import TokenStore from './tokenStore'
 import PrisonRegisterApiClient from './prisonRegisterApiClient'
@@ -21,6 +22,7 @@ type RestClientBuilder<T> = (token: string) => T
 export const dataAccess = () => ({
   applicationInfo,
   hmppsAuthClient: new HmppsAuthClient(new TokenStore(createRedisClient())),
+  manageUsersApiClient: new ManageUsersApiClient(),
   prisonRegisterApiClientBuilder: ((token: string) =>
     new PrisonRegisterApiClient(token)) as RestClientBuilder<PrisonRegisterApiClient>,
   visitSchedulerApiClientBuilder: ((token: string) =>
@@ -29,4 +31,4 @@ export const dataAccess = () => ({
 
 export type DataAccess = ReturnType<typeof dataAccess>
 
-export { HmppsAuthClient, PrisonRegisterApiClient, RestClientBuilder, VisitSchedulerApiClient }
+export { HmppsAuthClient, ManageUsersApiClient, PrisonRegisterApiClient, RestClientBuilder, VisitSchedulerApiClient }

--- a/server/data/manageUsersApiClient.test.ts
+++ b/server/data/manageUsersApiClient.test.ts
@@ -34,16 +34,4 @@ describe('manageUsersApiClient', () => {
       expect(output).toEqual(response)
     })
   })
-
-  describe('getUserRoles', () => {
-    it('should return data from api', async () => {
-      fakeManageUsersApiClient
-        .get('/users/me/roles')
-        .matchHeader('authorization', `Bearer ${token.access_token}`)
-        .reply(200, [{ roleCode: 'role1' }, { roleCode: 'role2' }])
-
-      const output = await manageUsersApiClient.getUserRoles(token.access_token)
-      expect(output).toEqual(['role1', 'role2'])
-    })
-  })
 })

--- a/server/data/manageUsersApiClient.test.ts
+++ b/server/data/manageUsersApiClient.test.ts
@@ -1,0 +1,49 @@
+import nock from 'nock'
+
+import config from '../config'
+import ManageUsersApiClient from './manageUsersApiClient'
+
+jest.mock('./tokenStore')
+
+const token = { access_token: 'token-1', expires_in: 300 }
+
+describe('manageUsersApiClient', () => {
+  let fakeManageUsersApiClient: nock.Scope
+  let manageUsersApiClient: ManageUsersApiClient
+
+  beforeEach(() => {
+    fakeManageUsersApiClient = nock(config.apis.manageUsersApi.url)
+    manageUsersApiClient = new ManageUsersApiClient()
+  })
+
+  afterEach(() => {
+    jest.resetAllMocks()
+    nock.cleanAll()
+  })
+
+  describe('getUser', () => {
+    it('should return data from api', async () => {
+      const response = { data: 'data' }
+
+      fakeManageUsersApiClient
+        .get('/users/me')
+        .matchHeader('authorization', `Bearer ${token.access_token}`)
+        .reply(200, response)
+
+      const output = await manageUsersApiClient.getUser(token.access_token)
+      expect(output).toEqual(response)
+    })
+  })
+
+  describe('getUserRoles', () => {
+    it('should return data from api', async () => {
+      fakeManageUsersApiClient
+        .get('/users/me/roles')
+        .matchHeader('authorization', `Bearer ${token.access_token}`)
+        .reply(200, [{ roleCode: 'role1' }, { roleCode: 'role2' }])
+
+      const output = await manageUsersApiClient.getUserRoles(token.access_token)
+      expect(output).toEqual(['role1', 'role2'])
+    })
+  })
+})

--- a/server/data/manageUsersApiClient.ts
+++ b/server/data/manageUsersApiClient.ts
@@ -1,0 +1,37 @@
+import logger from '../../logger'
+import config from '../config'
+import RestClient from './restClient'
+
+export interface User {
+  username: string
+  name?: string
+  active?: boolean
+  authSource?: string
+  uuid?: string
+  userId?: string
+  staffId?: number // deprecated, use userId
+  activeCaseLoadId?: string // deprecated, use user roles api
+}
+
+export interface UserRole {
+  roleCode: string
+}
+
+export default class ManageUsersApiClient {
+  constructor() {}
+
+  private static restClient(token: string): RestClient {
+    return new RestClient('Manage Users Api Client', config.apis.manageUsersApi, token)
+  }
+
+  getUser(token: string): Promise<User> {
+    logger.info('Getting user details: calling HMPPS Manage Users Api')
+    return ManageUsersApiClient.restClient(token).get<User>({ path: '/users/me' })
+  }
+
+  getUserRoles(token: string): Promise<string[]> {
+    return ManageUsersApiClient.restClient(token)
+      .get<UserRole[]>({ path: '/users/me/roles' })
+      .then(roles => roles.map(role => role.roleCode))
+  }
+}

--- a/server/data/manageUsersApiClient.ts
+++ b/server/data/manageUsersApiClient.ts
@@ -28,10 +28,4 @@ export default class ManageUsersApiClient {
     logger.info('Getting user details: calling HMPPS Manage Users Api')
     return ManageUsersApiClient.restClient(token).get<User>({ path: '/users/me' })
   }
-
-  getUserRoles(token: string): Promise<string[]> {
-    return ManageUsersApiClient.restClient(token)
-      .get<UserRole[]>({ path: '/users/me/roles' })
-      .then(roles => roles.map(role => role.roleCode))
-  }
 }

--- a/server/middleware/authorisationMiddleware.test.ts
+++ b/server/middleware/authorisationMiddleware.test.ts
@@ -35,28 +35,37 @@ describe('authorisationMiddleware', () => {
     jest.resetAllMocks()
   })
 
-  it('should return next when no required roles', async () => {
+  it('should return next when no required roles', () => {
     const res = createResWithToken({ authorities: [] })
 
-    await authorisationMiddleware()(req, res, next)
+    authorisationMiddleware()(req, res, next)
 
     expect(next).toHaveBeenCalled()
     expect(res.redirect).not.toHaveBeenCalled()
   })
 
-  it('should redirect when user has no authorised roles', async () => {
+  it('should redirect when user has no authorised roles', () => {
     const res = createResWithToken({ authorities: [] })
 
-    await authorisationMiddleware(['SOME_REQUIRED_ROLE'])(req, res, next)
+    authorisationMiddleware(['SOME_REQUIRED_ROLE'])(req, res, next)
 
     expect(next).not.toHaveBeenCalled()
     expect(res.redirect).toHaveBeenCalledWith('/authError')
   })
 
-  it('should return next when user has authorised role', async () => {
-    const res = createResWithToken({ authorities: ['SOME_REQUIRED_ROLE'] })
+  it('should return next when user has authorised role', () => {
+    const res = createResWithToken({ authorities: ['ROLE_SOME_REQUIRED_ROLE'] })
 
-    await authorisationMiddleware(['SOME_REQUIRED_ROLE'])(req, res, next)
+    authorisationMiddleware(['SOME_REQUIRED_ROLE'])(req, res, next)
+
+    expect(next).toHaveBeenCalled()
+    expect(res.redirect).not.toHaveBeenCalled()
+  })
+
+  it('should return next when user has authorised role and middleware created with ROLE_ prefix', () => {
+    const res = createResWithToken({ authorities: ['ROLE_SOME_REQUIRED_ROLE'] })
+
+    authorisationMiddleware(['ROLE_SOME_REQUIRED_ROLE'])(req, res, next)
 
     expect(next).toHaveBeenCalled()
     expect(res.redirect).not.toHaveBeenCalled()

--- a/server/middleware/authorisationMiddleware.ts
+++ b/server/middleware/authorisationMiddleware.ts
@@ -6,10 +6,13 @@ import asyncMiddleware from './asyncMiddleware'
 
 export default function authorisationMiddleware(authorisedRoles: string[] = []): RequestHandler {
   return asyncMiddleware((req, res, next) => {
+    // authorities in the user token will always be prefixed by ROLE_.
+    // Convert roles that are passed into this function without the prefix so that we match correctly.
+    const authorisedAuthorities = authorisedRoles.map(role => (role.startsWith('ROLE_') ? role : `ROLE_${role}`))
     if (res.locals?.user?.token) {
       const { authorities: roles = [] } = jwtDecode(res.locals.user.token) as { authorities?: string[] }
 
-      if (authorisedRoles.length && !roles.some(role => authorisedRoles.includes(role))) {
+      if (authorisedAuthorities.length && !roles.some(role => authorisedAuthorities.includes(role))) {
         logger.error('User is not authorised to access this')
         return res.redirect('/authError')
       }

--- a/server/services/healthCheck.ts
+++ b/server/services/healthCheck.ts
@@ -51,6 +51,7 @@ function gatherCheckInfo(aggregateStatus: Record<string, unknown>, currentStatus
 
 const apiChecks = [
   service('hmppsAuth', `${config.apis.hmppsAuth.url}/health/ping`, config.apis.hmppsAuth.agent),
+  service('manageUsersApi', `${config.apis.manageUsersApi.url}/health/ping`, config.apis.manageUsersApi.agent),
   ...(config.apis.tokenVerification.enabled
     ? [
         service(

--- a/server/services/index.ts
+++ b/server/services/index.ts
@@ -8,8 +8,13 @@ import IncentiveGroupService from './incentiveGroupService'
 import VisitService from './visitService'
 
 export const services = () => {
-  const { hmppsAuthClient, applicationInfo, prisonRegisterApiClientBuilder, visitSchedulerApiClientBuilder } =
-    dataAccess()
+  const {
+    hmppsAuthClient,
+    applicationInfo,
+    manageUsersApiClient,
+    prisonRegisterApiClientBuilder,
+    visitSchedulerApiClientBuilder,
+  } = dataAccess()
 
   const categoryGroupService = new CategoryGroupService(visitSchedulerApiClientBuilder, hmppsAuthClient)
 
@@ -25,7 +30,7 @@ export const services = () => {
 
   const sessionTemplateService = new SessionTemplateService(visitSchedulerApiClientBuilder, hmppsAuthClient)
 
-  const userService = new UserService(hmppsAuthClient)
+  const userService = new UserService(manageUsersApiClient)
 
   const visitService = new VisitService(visitSchedulerApiClientBuilder, hmppsAuthClient)
 

--- a/server/services/userService.test.ts
+++ b/server/services/userService.test.ts
@@ -1,9 +1,8 @@
 import UserService from './userService'
 import ManageUsersApiClient, { type User } from '../data/manageUsersApiClient'
+import createUserToken from '../testutils/createUserToken'
 
 jest.mock('../data/manageUsersApiClient')
-
-const token = 'some token'
 
 describe('User service', () => {
   let manageUsersApiClient: jest.Mocked<ManageUsersApiClient>
@@ -16,6 +15,7 @@ describe('User service', () => {
     })
 
     it('Retrieves and formats user name', async () => {
+      const token = createUserToken([])
       manageUsersApiClient.getUser.mockResolvedValue({ name: 'john smith' } as User)
 
       const result = await userService.getUser(token)
@@ -23,7 +23,17 @@ describe('User service', () => {
       expect(result.displayName).toEqual('John Smith')
     })
 
+    it('Retrieves and formats roles', async () => {
+      const token = createUserToken(['ROLE_ONE', 'ROLE_TWO'])
+      manageUsersApiClient.getUser.mockResolvedValue({ name: 'john smith' } as User)
+
+      const result = await userService.getUser(token)
+
+      expect(result.roles).toEqual(['ONE', 'TWO'])
+    })
+
     it('Propagates error', async () => {
+      const token = createUserToken([])
       manageUsersApiClient.getUser.mockRejectedValue(new Error('some error'))
 
       await expect(userService.getUser(token)).rejects.toEqual(new Error('some error'))

--- a/server/services/userService.test.ts
+++ b/server/services/userService.test.ts
@@ -1,28 +1,30 @@
 import UserService from './userService'
-import HmppsAuthClient, { User } from '../data/hmppsAuthClient'
+import ManageUsersApiClient, { type User } from '../data/manageUsersApiClient'
 
-jest.mock('../data/hmppsAuthClient')
+jest.mock('../data/manageUsersApiClient')
 
 const token = 'some token'
 
 describe('User service', () => {
-  let hmppsAuthClient: jest.Mocked<HmppsAuthClient>
+  let manageUsersApiClient: jest.Mocked<ManageUsersApiClient>
   let userService: UserService
 
   describe('getUser', () => {
     beforeEach(() => {
-      hmppsAuthClient = new HmppsAuthClient(null) as jest.Mocked<HmppsAuthClient>
-      userService = new UserService(hmppsAuthClient)
+      manageUsersApiClient = new ManageUsersApiClient() as jest.Mocked<ManageUsersApiClient>
+      userService = new UserService(manageUsersApiClient)
     })
+
     it('Retrieves and formats user name', async () => {
-      hmppsAuthClient.getUser.mockResolvedValue({ name: 'john smith' } as User)
+      manageUsersApiClient.getUser.mockResolvedValue({ name: 'john smith' } as User)
 
       const result = await userService.getUser(token)
 
       expect(result.displayName).toEqual('John Smith')
     })
+
     it('Propagates error', async () => {
-      hmppsAuthClient.getUser.mockRejectedValue(new Error('some error'))
+      manageUsersApiClient.getUser.mockRejectedValue(new Error('some error'))
 
       await expect(userService.getUser(token)).rejects.toEqual(new Error('some error'))
     })

--- a/server/services/userService.ts
+++ b/server/services/userService.ts
@@ -1,9 +1,11 @@
+import { jwtDecode } from 'jwt-decode'
 import { convertToTitleCase } from '../utils/utils'
 import type { User } from '../data/manageUsersApiClient'
 import ManageUsersApiClient from '../data/manageUsersApiClient'
 
 export interface UserDetails extends User {
   displayName: string
+  roles: string[]
 }
 
 export default class UserService {
@@ -11,6 +13,11 @@ export default class UserService {
 
   async getUser(token: string): Promise<UserDetails> {
     const user = await this.manageUsersApiClient.getUser(token)
-    return { ...user, displayName: convertToTitleCase(user.name) }
+    return { ...user, roles: this.getUserRoles(token), displayName: convertToTitleCase(user.name) }
+  }
+
+  getUserRoles(token: string): string[] {
+    const { authorities: roles = [] } = jwtDecode(token) as { authorities?: string[] }
+    return roles.map(role => role.substring(role.indexOf('_') + 1))
   }
 }

--- a/server/services/userService.ts
+++ b/server/services/userService.ts
@@ -1,16 +1,16 @@
 import { convertToTitleCase } from '../utils/utils'
-import type HmppsAuthClient from '../data/hmppsAuthClient'
+import type { User } from '../data/manageUsersApiClient'
+import ManageUsersApiClient from '../data/manageUsersApiClient'
 
-interface UserDetails {
-  name: string
+export interface UserDetails extends User {
   displayName: string
 }
 
 export default class UserService {
-  constructor(private readonly hmppsAuthClient: HmppsAuthClient) {}
+  constructor(private readonly manageUsersApiClient: ManageUsersApiClient) {}
 
   async getUser(token: string): Promise<UserDetails> {
-    const user = await this.hmppsAuthClient.getUser(token)
+    const user = await this.manageUsersApiClient.getUser(token)
     return { ...user, displayName: convertToTitleCase(user.name) }
   }
 }

--- a/server/testutils/createUserToken.ts
+++ b/server/testutils/createUserToken.ts
@@ -1,0 +1,14 @@
+import jwt from 'jsonwebtoken'
+
+export default function createUserToken(authorities: string[]) {
+  const payload = {
+    user_name: 'user1',
+    scope: ['read', 'write'],
+    auth_source: 'nomis',
+    authorities,
+    jti: 'a610a10-cca6-41db-985f-e87efb303aaf',
+    client_id: 'clientid',
+  }
+
+  return jwt.sign(payload, 'secret', { expiresIn: '1h' })
+}


### PR DESCRIPTION
Update to use `hmpps-manage-users-api` instead of `hmpps-auth` for certain endpoints. Changes copied from typescript template app.