### PR TITLE
VB-4330 Handle contact registry API errors

### DIFF
--- a/server/views/pages/bookers/booker/details.njk
+++ b/server/views/pages/bookers/booker/details.njk
@@ -65,8 +65,8 @@
               text: visitor.visitorId
             },
             {
-              html: visitor.dateOfBirth | formatDate +
-                '<br>(' + visitor.dateOfBirth | displayAge + ')'
+              html: (visitor.dateOfBirth | formatDate +
+                '<br>(' + visitor.dateOfBirth | displayAge + ')') if visitor.dateOfBirth
             },
             {
               text: visitor.approved


### PR DESCRIPTION
When managing bookers and their configured prisoners/visitors, handle API errors from the contact registry by assuming an empty response and showing an info message with the error details.

If a prisoner has been released, for example, the `403` from the contact registry in this case otherwise prevents editing of the booker.

(n.b. no tests for this as test coverage for booker management as a whole coming in next PR!)