### PR TITLE
VB-3340 Booker management: add/edit a prisoner's registered prison

### DIFF
--- a/integration_tests/e2e/bookers/bookerManagement.cy.ts
+++ b/integration_tests/e2e/bookers/bookerManagement.cy.ts
@@ -24,6 +24,8 @@ context('Booker management', () => {
     cy.task('reset')
     cy.task('stubSignIn')
     cy.task('stubManageUser')
+    cy.task('stubGetAllPrisons')
+    cy.task('stubPrisonNames')
     cy.signIn()
   })
 
@@ -55,6 +57,7 @@ context('Booker management', () => {
     bookerDetailsPage.addPrisoner()
     const addPrisonerPage = Page.verifyOnPage(AddPrisonerPage)
     addPrisonerPage.enterPrisonerNumber(prisoner.prisonerId)
+    addPrisonerPage.selectPrison(prisoner.prisonCode)
     cy.task('stubCreateBookerPrisoner', { booker, prisoner })
     cy.task('stubGetBookerByEmail', bookerWithPrisoner)
     cy.task('stubGetSocialContacts', { prisonerId: prisoner.prisonerId, contacts: [contact], approvedOnly: false })
@@ -63,6 +66,7 @@ context('Booker management', () => {
     // Booker details - prisoner added
     bookerDetailsPage.checkOnPage()
     bookerDetailsPage.prisonerNumber().contains(prisoner.prisonerId)
+    bookerDetailsPage.prisonName().contains('Hewell (HMP)')
 
     // Add visitor
     cy.task('stubGetSocialContacts', { prisonerId: prisoner.prisonerId, contacts: [contact], approvedOnly: true })

--- a/integration_tests/mockApis/bookerRegistry.ts
+++ b/integration_tests/mockApis/bookerRegistry.ts
@@ -68,6 +68,7 @@ export default {
             equalToJson: {
               prisonerId: prisoner.prisonerId,
               active: true,
+              prisonCode: prisoner.prisonCode,
             },
           },
         ],

--- a/integration_tests/pages/bookers/addPrisoner.ts
+++ b/integration_tests/pages/bookers/addPrisoner.ts
@@ -9,6 +9,10 @@ export default class AddPrisonerPage extends Page {
     cy.get('#prisonerNumber').type(prisonerNumber)
   }
 
+  selectPrison = (prisonCode: string): void => {
+    cy.get('#prisonCode').select(prisonCode)
+  }
+
   addPrisoner = (): void => {
     cy.get('[data-test="add-prisoner"]').click()
   }

--- a/integration_tests/pages/bookers/bookerDetails.ts
+++ b/integration_tests/pages/bookers/bookerDetails.ts
@@ -11,7 +11,7 @@ export default class BookerDetailsPage extends Page {
 
   prisonerNumber = (): PageElement => cy.get('[data-test="prisoner-number"]')
 
-  prisonName = (): PageElement => cy.get('[data-test="prison-name"]')
+  prisonName = (): PageElement => cy.get('[data-test="registered-prison-name"]')
 
   addPrisoner = (): void => {
     cy.get('[data-test="add-prisoner"]').click()

--- a/integration_tests/pages/bookers/bookerDetails.ts
+++ b/integration_tests/pages/bookers/bookerDetails.ts
@@ -11,6 +11,8 @@ export default class BookerDetailsPage extends Page {
 
   prisonerNumber = (): PageElement => cy.get('[data-test="prisoner-number"]')
 
+  prisonName = (): PageElement => cy.get('[data-test="prison-name"]')
+
   addPrisoner = (): void => {
     cy.get('[data-test="add-prisoner"]').click()
   }

--- a/server/@types/booker-registry-api.d.ts
+++ b/server/@types/booker-registry-api.d.ts
@@ -184,6 +184,26 @@ export interface paths {
     patch?: never
     trace?: never
   }
+  '/public/booker/{bookerReference}/permitted/prisoners/{prisonerId}/validate': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /**
+     * Validates a prisoner for whom the booker is about to book a visit
+     * @description Validates a prisoner for whom the booker is about to book a visit
+     */
+    get: operations['validatePrisoner']
+    put?: never
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
   '/public/booker/{bookerReference}/permitted/prisoners/{prisonerId}/permitted/visitors': {
     parameters: {
       query?: never
@@ -308,6 +328,11 @@ export interface components {
        * @example true
        */
       active: boolean
+      /**
+       * @description prison code
+       * @example MDI
+       */
+      prisonCode: string
       /** @description Permitted visitors */
       permittedVisitors: components['schemas']['PermittedVisitorDto'][]
     }
@@ -333,6 +358,11 @@ export interface components {
        */
       prisonerId: string
       /**
+       * @description prison code
+       * @example MDI
+       */
+      prisonCode: string
+      /**
        * @description Active / Inactive permitted prisoner
        * @example true
        */
@@ -351,6 +381,16 @@ export interface components {
        * @example true
        */
       active: boolean
+    }
+    BookerPrisonerValidationErrorResponse: {
+      validationError: string
+      /** Format: int32 */
+      status: number
+      /** Format: int32 */
+      errorCode?: number
+      userMessage?: string
+      developerMessage?: string
+      moreInfo?: string
     }
   }
   responses: never
@@ -863,6 +903,58 @@ export interface operations {
         }
         content: {
           'application/json': components['schemas']['ErrorResponse']
+        }
+      }
+    }
+  }
+  validatePrisoner: {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        bookerReference: string
+        /**
+         * @description Prisoner Id for that needs to be validated.
+         * @example A12345DC
+         */
+        prisonerId: string
+      }
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Validation passed */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description Incorrect request to get permitted visitors for a prisoner associated with that booker */
+      400: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ErrorResponse']
+        }
+      }
+      /** @description Incorrect permissions for this action */
+      403: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ErrorResponse']
+        }
+      }
+      /** @description Prisoner validation failed */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['BookerPrisonerValidationErrorResponse']
         }
       }
     }

--- a/server/@types/prison-register-api.d.ts
+++ b/server/@types/prison-register-api.d.ts
@@ -232,7 +232,7 @@ export interface paths {
       cookie?: never
     }
     /**
-     * Get prison names
+     * Get prison name(s)
      * @description prison id and full name
      */
     get: operations['getPrisonNames']
@@ -370,6 +370,8 @@ export interface components {
       female: boolean
       /** @description If this is a contracted prison */
       contracted: boolean
+      /** @description If this prison is part of the long term high security estate */
+      lthse: boolean
       /** @description Set of types for this prison */
       prisonTypes: ('HMP' | 'YOI' | 'IRC' | 'STC' | 'YCS')[]
       /** @description Set of categories for this prison */
@@ -434,6 +436,8 @@ export interface components {
       female: boolean
       /** @description Whether the prison is contracted */
       contracted: boolean
+      /** @description Whether the prison is part of long term high security estate */
+      lthse: boolean
       /** @description List of types for this prison */
       types: components['schemas']['PrisonTypeDto'][]
       /** @description List of the categories for this prison */
@@ -522,6 +526,8 @@ export interface components {
       female: boolean
       /** @description If this is a contracted prison */
       contracted: boolean
+      /** @description If this prison is part of the long term high security estate */
+      lthse: boolean
       /**
        * @description Set of types for this prison
        * @example HMP
@@ -1436,6 +1442,11 @@ export interface operations {
          */
         active?: boolean
         /**
+         * @description Long Term High Security Estate
+         * @example true
+         */
+        lthse?: boolean
+        /**
          * @description Text search
          * @example Sheffield
          */
@@ -1470,7 +1481,18 @@ export interface operations {
   }
   getPrisonNames: {
     parameters: {
-      query?: never
+      query?: {
+        /**
+         * @description If active is not set, return all prisons, otherwise return only the active or inactive ones based on the value
+         * @example true
+         */
+        active?: boolean
+        /**
+         * @description If parameter prisonId is not set, return the names of all prisons, otherwise return only the one corresponding to the prisonId code.  Filtering on active still applies
+         * @example WDI
+         */
+        prison_id?: string
+      }
       header?: never
       path?: never
       cookie?: never

--- a/server/@types/prisoner-contact-registry-api.d.ts
+++ b/server/@types/prisoner-contact-registry-api.d.ts
@@ -4,6 +4,86 @@
  */
 
 export interface paths {
+  '/v2/prisoners/{prisonerId}/contacts/social': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /**
+     * Get Prisoners Social Contacts
+     * @description Returns details of a prisoner's social contacts
+     */
+    get: operations['getPrisonerSocialContacts']
+    put?: never
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  '/v2/prisoners/{prisonerId}/contacts/social/approved': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /**
+     * Get Prisoners Social Contacts that are approved
+     * @description Returns details of a prisoner's social contacts that have been approved.
+     */
+    get: operations['getPrisonersSocialContactsApproved']
+    put?: never
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  '/v2/prisoners/{prisonerId}/contacts/social/approved/restrictions/closed': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /**
+     * Get status on any visitors having closed restrictions
+     * @description Returns a boolean true/false for a given list of visitors if any closed restrictions are found
+     */
+    get: operations['getClosedRestrictionStatusForPrisonerVisitors']
+    put?: never
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  '/v2/prisoners/{prisonerId}/contacts/social/approved/restrictions/banned/dateRange': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /**
+     * Get an updated date range for visitors if a visitor with ban restriction is found, else returns original date
+     * @description Returns an updated date range for visitors if one is found with an active ban restriction. If not, it returns the original date range
+     */
+    get: operations['getUpdatedDateRangeForPrisonerVisitorsIfFoundWithBanRestrictions']
+    put?: never
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
   '/prisoners/{prisonerId}/contacts': {
     parameters: {
       query?: never
@@ -13,6 +93,7 @@ export interface paths {
     }
     /**
      * Get Prisoner Contact
+     * @deprecated
      * @description Returns details of a prisoner contacts
      */
     get: operations['getPrisonerContact']
@@ -33,9 +114,10 @@ export interface paths {
     }
     /**
      * Get Prisoners Social Contacts
+     * @deprecated
      * @description Returns details of a prisoner's social contacts
      */
-    get: operations['getPrisonerSocialContacts']
+    get: operations['getPrisonerSocialContacts_1']
     put?: never
     post?: never
     delete?: never
@@ -74,9 +156,10 @@ export interface paths {
     }
     /**
      * Get status on any visitors having closed restrictions
+     * @deprecated
      * @description Returns a boolean true/false for a given list of visitors if any closed restrictions are found
      */
-    get: operations['getClosedRestrictionStatusForPrisonerVisitors']
+    get: operations['getClosedRestrictionStatusForPrisonerVisitors_1']
     put?: never
     post?: never
     delete?: never
@@ -94,9 +177,10 @@ export interface paths {
     }
     /**
      * Get an updated date range for visitors if a visitor with ban restriction is found, else returns original date
+     * @deprecated
      * @description Returns an updated date range for visitors if one is found with an active ban restriction. If not, it returns the original date range
      */
-    get: operations['getUpdatedDateRangeForPrisonerVisitorsIfFoundWithBanRestrictions']
+    get: operations['getUpdatedDateRangeForPrisonerVisitorsIfFoundWithBanRestrictions_1']
     put?: never
     post?: never
     delete?: never
@@ -356,6 +440,298 @@ export interface components {
 }
 export type $defs = Record<string, never>
 export interface operations {
+  getPrisonerSocialContacts: {
+    parameters: {
+      query?: {
+        /**
+         * @description Defaults to false. By default when false, returns all contacts with or without a DOB. If true, returns only contacts with a DOB.
+         * @example false
+         */
+        hasDateOfBirth?: boolean
+        /**
+         * @description by default returns addresses for all contacts, set to false if contact addresses not needed.
+         * @example false
+         */
+        withAddress?: boolean
+      }
+      header?: never
+      path: {
+        /**
+         * @description Prisoner Identifier (NOMIS Offender No)
+         * @example A1234AA
+         */
+        prisonerId: string
+      }
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Prisoner Social Contacts Information Returned */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ContactDto'][]
+        }
+      }
+      /** @description Incorrect request to retrieve prisoner's approved social contacts */
+      400: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ErrorResponse']
+        }
+      }
+      /** @description Unauthorized to access this endpoint */
+      401: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ErrorResponse']
+        }
+      }
+      /** @description Incorrect permissions to retrieve prisoner's approved social contacts */
+      403: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ErrorResponse']
+        }
+      }
+      /** @description Prisoner not found */
+      404: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ErrorResponse']
+        }
+      }
+    }
+  }
+  getPrisonersSocialContactsApproved: {
+    parameters: {
+      query?: {
+        /**
+         * @description Defaults to false. By default when false, returns all contacts with or without a DOB. If true, returns only contacts with a DOB.
+         * @example false
+         */
+        hasDateOfBirth?: boolean
+        /**
+         * @description by default returns addresses for all contacts, set to false if contact addresses not needed.
+         * @example false
+         */
+        withAddress?: boolean
+      }
+      header?: never
+      path: {
+        /**
+         * @description Prisoner Identifier (NOMIS Offender No)
+         * @example A1234AA
+         */
+        prisonerId: string
+      }
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Prisoner Approved Social Contacts Information Returned */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ContactDto'][]
+        }
+      }
+      /** @description Incorrect request to retrieve prisoner's approved social contacts */
+      400: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ErrorResponse']
+        }
+      }
+      /** @description Unauthorized to access this endpoint */
+      401: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ErrorResponse']
+        }
+      }
+      /** @description Incorrect permissions to retrieve prisoner's approved social contacts */
+      403: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ErrorResponse']
+        }
+      }
+      /** @description Prisoner not found */
+      404: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ErrorResponse']
+        }
+      }
+    }
+  }
+  getClosedRestrictionStatusForPrisonerVisitors: {
+    parameters: {
+      query: {
+        /**
+         * @description Ids of prisoner visitors
+         * @example 9147510, 8431201
+         */
+        visitors: number[]
+      }
+      header?: never
+      path: {
+        /**
+         * @description Prisoner Identifier (NOMIS Offender No)
+         * @example A1234AA
+         */
+        prisonerId: string
+      }
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Returned status on visitor closed restrictions successfully */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['HasClosedRestrictionDto']
+        }
+      }
+      /** @description Incorrect request to Get status of visitors closed restrictions */
+      400: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ErrorResponse']
+        }
+      }
+      /** @description Unauthorized to access this endpoint */
+      401: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ErrorResponse']
+        }
+      }
+      /** @description Incorrect permissions to Get status of visitors closed restrictions */
+      403: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ErrorResponse']
+        }
+      }
+      /** @description Prisoner or Visitor */
+      404: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ErrorResponse']
+        }
+      }
+    }
+  }
+  getUpdatedDateRangeForPrisonerVisitorsIfFoundWithBanRestrictions: {
+    parameters: {
+      query: {
+        /**
+         * @description Ids of prisoner visitors
+         * @example 9147510, 8431201
+         */
+        visitors: number[]
+        /**
+         * @description Start date range
+         * @example 2024-03-15
+         */
+        fromDate: string
+        /**
+         * @description To date range
+         * @example 2024-03-31
+         */
+        toDate: string
+      }
+      header?: never
+      path: {
+        /**
+         * @description Prisoner Identifier (NOMIS Offender No)
+         * @example A1234AA
+         */
+        prisonerId: string
+      }
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Date range returned (original or adjusted) */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['DateRangeDto']
+        }
+      }
+      /** @description Incorrect request to Get date range for prisoner visitors */
+      400: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ErrorResponse']
+        }
+      }
+      /** @description Unauthorized to access this endpoint */
+      401: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ErrorResponse']
+        }
+      }
+      /** @description Incorrect permissions to Get date range for prisoner visitors */
+      403: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ErrorResponse']
+        }
+      }
+      /** @description Prisoner, Visitor or Date range not found */
+      404: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ErrorResponse']
+        }
+      }
+    }
+  }
   getPrisonerContact: {
     parameters: {
       query?: {
@@ -434,7 +810,7 @@ export interface operations {
       }
     }
   }
-  getPrisonerSocialContacts: {
+  getPrisonerSocialContacts_1: {
     parameters: {
       query?: {
         /**
@@ -605,7 +981,7 @@ export interface operations {
       }
     }
   }
-  getClosedRestrictionStatusForPrisonerVisitors: {
+  getClosedRestrictionStatusForPrisonerVisitors_1: {
     parameters: {
       query: {
         /**
@@ -673,7 +1049,7 @@ export interface operations {
       }
     }
   }
-  getUpdatedDateRangeForPrisonerVisitorsIfFoundWithBanRestrictions: {
+  getUpdatedDateRangeForPrisonerVisitorsIfFoundWithBanRestrictions_1: {
     parameters: {
       query: {
         /**

--- a/server/@types/visit-scheduler-api.d.ts
+++ b/server/@types/visit-scheduler-api.d.ts
@@ -2001,7 +2001,7 @@ export interface components {
       pageable?: components['schemas']['PageableObject']
       /** Format: int32 */
       size?: number
-      sort?: components['schemas']['SortObject'][]
+      sort?: components['schemas']['SortObject']
       /** Format: int64 */
       totalElements?: number
       /** Format: int32 */
@@ -2015,7 +2015,7 @@ export interface components {
       /** Format: int32 */
       pageSize?: number
       paged?: boolean
-      sort?: components['schemas']['SortObject'][]
+      sort?: components['schemas']['SortObject']
       unpaged?: boolean
     }
     /** @description list of locations for group */
@@ -2425,11 +2425,9 @@ export interface components {
       startTime: string
     }
     SortObject: {
-      ascending?: boolean
-      direction?: string
-      ignoreCase?: boolean
-      nullHandling?: string
-      property?: string
+      empty?: boolean
+      sorted?: boolean
+      unsorted?: boolean
     }
     UpdateCategoryGroupDto: {
       /** @description list of category for group */
@@ -2763,6 +2761,11 @@ export interface components {
        */
       description: string
     }
+    /**
+     * @description Visit Restriction - OPEN / CLOSED / UNKNOWN
+     * @example OPEN
+     */
+    visitRestrictions: ('OPEN' | 'CLOSED' | 'UNKNOWN')[]
   }
   responses: never
   parameters: never
@@ -3785,7 +3788,7 @@ export interface operations {
          * @description type
          * @example STAFF
          */
-        type: string
+        type: 'STAFF' | 'PUBLIC' | 'SYSTEM'
       }
       cookie?: never
     }
@@ -3843,7 +3846,7 @@ export interface operations {
          * @description type
          * @example STAFF
          */
-        type: string
+        type: 'STAFF' | 'PUBLIC' | 'SYSTEM'
       }
       cookie?: never
     }
@@ -4710,7 +4713,7 @@ export interface operations {
          * @description type
          * @example STAFF
          */
-        type: string
+        type: 'STAFF' | 'PUBLIC' | 'SYSTEM'
       }
       cookie?: never
     }
@@ -7161,7 +7164,7 @@ export interface operations {
          * @description Visit Restriction - OPEN / CLOSED / UNKNOWN
          * @example OPEN
          */
-        visitRestrictions?: string
+        visitRestrictions?: components['schemas']['visitRestrictions']
         /**
          * @description Filter results by visit status
          * @example BOOKED

--- a/server/data/bookerRegistryApiClient.test.ts
+++ b/server/data/bookerRegistryApiClient.test.ts
@@ -71,11 +71,16 @@ describe('bookerRegistryApiClient', () => {
           .put(`/public/booker/config/${booker.reference}/prisoner`, <CreatePermittedPrisonerDto>{
             prisonerId: prisoner.prisonerId,
             active: true,
+            prisonCode: prisoner.prisonCode,
           })
           .matchHeader('authorization', `Bearer ${token}`)
           .reply(201, prisoner)
 
-        const output = await bookerRegistryApiClient.addPrisoner(booker.reference, prisoner.prisonerId)
+        const output = await bookerRegistryApiClient.addPrisoner(
+          booker.reference,
+          prisoner.prisonerId,
+          prisoner.prisonCode,
+        )
         expect(output).toStrictEqual(prisoner)
       })
     })

--- a/server/data/bookerRegistryApiClient.ts
+++ b/server/data/bookerRegistryApiClient.ts
@@ -31,10 +31,10 @@ export default class BookerRegistryApiClient {
 
   // Prisoner
 
-  async addPrisoner(bookerReference: string, prisonerId: string): Promise<PermittedPrisonerDto> {
+  async addPrisoner(bookerReference: string, prisonerId: string, prisonCode: string): Promise<PermittedPrisonerDto> {
     return this.restClient.put({
       path: `/public/booker/config/${bookerReference}/prisoner`,
-      data: <CreatePermittedPrisonerDto>{ prisonerId, active: true },
+      data: <CreatePermittedPrisonerDto>{ prisonerId, active: true, prisonCode },
     })
   }
 

--- a/server/routes/bookers/booker/bookerDetailsController.test.ts
+++ b/server/routes/bookers/booker/bookerDetailsController.test.ts
@@ -3,7 +3,11 @@ import request from 'supertest'
 import * as cheerio from 'cheerio'
 import { SessionData } from 'express-session'
 import { appWithAllRoutes, flashProvider } from '../../testutils/appSetup'
-import { createMockBookerService, createMockPrisonerContactsService } from '../../../services/testutils/mocks'
+import {
+  createMockBookerService,
+  createMockPrisonerContactsService,
+  createMockPrisonService,
+} from '../../../services/testutils/mocks'
 import TestData from '../../testutils/testData'
 import { FlashErrorMessage } from '../../../@types/visits-admin'
 
@@ -12,6 +16,7 @@ let flashData: Record<string, string | Record<string, string>[] | FlashErrorMess
 
 const bookerService = createMockBookerService()
 const prisonerContactsService = createMockPrisonerContactsService()
+const prisonService = createMockPrisonService()
 let sessionData: SessionData
 
 beforeEach(() => {
@@ -19,7 +24,9 @@ beforeEach(() => {
   flashProvider.mockImplementation(key => flashData[key])
   sessionData = {} as SessionData
 
-  app = appWithAllRoutes({ services: { bookerService, prisonerContactsService }, sessionData })
+  prisonService.getPrisonName.mockResolvedValue('Hewell (HMP)')
+
+  app = appWithAllRoutes({ services: { bookerService, prisonerContactsService, prisonService }, sessionData })
 })
 
 afterEach(() => {
@@ -55,6 +62,7 @@ describe('Booker details', () => {
           expect($('[data-test=booker-reference]').text()).toBe(booker.reference)
 
           expect($('[data-test=prisoner-number]').text()).toBe(prisoner.prisonerId)
+          expect($('[data-test=prison-name]').text()).toBe('Hewell (HMP)')
           expect($('[data-test=prisoner-status]').text().trim()).toBe('Active')
 
           expect($('[data-test=visitor-name-1]').text()).toBe(`${contact.firstName} ${contact.lastName}`)
@@ -70,6 +78,7 @@ describe('Booker details', () => {
             prisonerId: prisoner.prisonerId,
             approvedOnly: false,
           })
+          expect(prisonService.getPrisonName).toHaveBeenCalledWith('user1', prisoner.prisonCode)
         })
     })
 

--- a/server/routes/bookers/booker/bookerDetailsController.test.ts
+++ b/server/routes/bookers/booker/bookerDetailsController.test.ts
@@ -62,7 +62,7 @@ describe('Booker details', () => {
           expect($('[data-test=booker-reference]').text()).toBe(booker.reference)
 
           expect($('[data-test=prisoner-number]').text()).toBe(prisoner.prisonerId)
-          expect($('[data-test=prison-name]').text()).toBe('Hewell (HMP)')
+          expect($('[data-test=registered-prison-name]').text()).toBe('Hewell (HMP)')
           expect($('[data-test=prisoner-status]').text().trim()).toBe('Active')
 
           expect($('[data-test=visitor-name-1]').text()).toBe(`${contact.firstName} ${contact.lastName}`)

--- a/server/routes/bookers/booker/bookerDetailsController.ts
+++ b/server/routes/bookers/booker/bookerDetailsController.ts
@@ -1,5 +1,5 @@
 import { RequestHandler } from 'express'
-import { BookerService, PrisonerContactsService } from '../../../services'
+import { BookerService, PrisonerContactsService, PrisonService } from '../../../services'
 import { ContactDto } from '../../../data/prisonerContactRegistryApiTypes'
 import { responseErrorToFlashMessage } from '../../../utils/utils'
 
@@ -15,6 +15,7 @@ export default class BookerDetailsController {
   public constructor(
     private readonly bookerService: BookerService,
     private readonly prisonerContactsService: PrisonerContactsService,
+    private readonly prisonService: PrisonService,
   ) {}
 
   public view(): RequestHandler {
@@ -25,6 +26,8 @@ export default class BookerDetailsController {
       req.session.booker = booker
 
       const prisoner = booker.permittedPrisoners[0] ?? undefined
+      const prisonName =
+        prisoner && (await this.prisonService.getPrisonName(res.locals.user.username, prisoner.prisonCode))
 
       let contacts: ContactDto[]
       try {
@@ -66,6 +69,7 @@ export default class BookerDetailsController {
         errors: req.flash('errors'),
         message: req.flash('message')?.[0] || {},
         booker,
+        prisonName,
         visitors,
       })
     }

--- a/server/routes/bookers/booker/editPrisonerController.ts
+++ b/server/routes/bookers/booker/editPrisonerController.ts
@@ -1,0 +1,107 @@
+import { RequestHandler } from 'express'
+import { ValidationChain, body, validationResult } from 'express-validator'
+import { BookerService, PrisonService } from '../../../services'
+import { responseErrorToFlashMessage } from '../../../utils/utils'
+
+export default class EditPrisonerController {
+  public constructor(
+    private readonly bookerService: BookerService,
+    private readonly prisonService: PrisonService,
+  ) {}
+
+  public view(): RequestHandler {
+    return async (req, res) => {
+      const { booker } = req.session
+      const prisoner = booker.permittedPrisoners[0]
+
+      if (!prisoner) {
+        return res.redirect('/bookers/booker/details')
+      }
+
+      const currentPrisonName = await this.prisonService.getPrisonName(res.locals.user.username, prisoner.prisonCode)
+
+      const prisons = await this.prisonService.getAllPrisons(res.locals.user.username)
+      const prisonSelectItems = prisons.map(prison => ({ value: prison.code, text: prison.name }))
+
+      return res.render('pages/bookers/booker/editPrisoner', {
+        errors: req.flash('errors'),
+        formValues: req.flash('formValues')?.[0] || {},
+        booker,
+        prisoner,
+        currentPrisonName,
+        prisonSelectItems,
+      })
+    }
+  }
+
+  public submit(): RequestHandler {
+    return async (req, res) => {
+      const errors = validationResult(req)
+      if (!errors.isEmpty()) {
+        req.flash('errors', errors.array())
+        req.flash('formValues', req.body)
+        return res.redirect('/bookers/booker/edit-prisoner')
+      }
+
+      const { booker } = req.session
+      const prisoner = booker.permittedPrisoners[0]
+
+      if (!prisoner) {
+        return res.redirect('/bookers/booker/details')
+      }
+
+      const { prisonCode }: { prisonCode: string } = req.body
+
+      try {
+        // Update details by clearing booker's prisoner/visitor details and re-creating
+        // (temporary implementation, pending user registration journey)
+        await this.bookerService.clearBookerDetails(res.locals.user.username, booker.reference)
+
+        await this.bookerService.addPrisoner(
+          res.locals.user.username,
+          booker.reference,
+          prisoner.prisonerId,
+          prisonCode,
+        )
+
+        // defaults to creating 'active' so check if necessary to deactivate
+        if (!prisoner.active) {
+          await this.bookerService.deactivatePrisoner(res.locals.user.username, booker.reference, prisoner.prisonerId)
+        }
+
+        prisoner.permittedVisitors.forEach(async visitor => {
+          await this.bookerService.addVisitor(
+            res.locals.user.username,
+            booker.reference,
+            prisoner.prisonerId,
+            visitor.visitorId,
+          )
+          // defaults to creating 'active' so check if necessary to deactivate
+          if (!visitor.active) {
+            await this.bookerService.deactivateVisitor(
+              res.locals.user.username,
+              booker.reference,
+              prisoner.prisonerId,
+              visitor.visitorId,
+            )
+          }
+        })
+
+        // clear session and re-load data
+        delete req.session.booker
+        req.session.booker = await this.bookerService.getBookerByEmail(res.locals.user.username, booker.email)
+
+        req.flash('message', { text: `Prison updated`, type: 'success' })
+        return res.redirect('/bookers/booker/details')
+      } catch (error) {
+        req.flash('errors', responseErrorToFlashMessage(error))
+        req.flash('formValues', req.body)
+        return res.redirect('/bookers/booker/edit-prisoner')
+      }
+    }
+  }
+
+  public validate(): ValidationChain[] {
+    return [body('prisonCode', 'Select a prison').matches(/^[A-Z]{3}$/)]
+  }
+}

--- a/server/routes/bookers/booker/index.ts
+++ b/server/routes/bookers/booker/index.ts
@@ -7,6 +7,7 @@ import AddPrisonerController from './addPrisonerController'
 import PrisonerStatusController from './prisonerStatusController'
 import AddVisitorController from './addVisitorController'
 import VisitorStatusController from './visitorStatusController'
+import EditPrisonerController from './editPrisonerController'
 
 export default function routes(services: Services): Router {
   const router = Router()
@@ -22,6 +23,7 @@ export default function routes(services: Services): Router {
     services.prisonService,
   )
   const addPrisoner = new AddPrisonerController(services.bookerService, services.prisonService)
+  const editPrisoner = new EditPrisonerController(services.bookerService, services.prisonService)
   const prisonerStatus = new PrisonerStatusController(services.bookerService)
   const addVisitor = new AddVisitorController(services.bookerService, services.prisonerContactsService)
   const visitorStatus = new VisitorStatusController(services.bookerService)
@@ -40,6 +42,9 @@ export default function routes(services: Services): Router {
 
   get('/add-prisoner', addPrisoner.view())
   postWithValidation('/add-prisoner', addPrisoner.validate(), addPrisoner.submit())
+
+  get('/edit-prisoner', editPrisoner.view())
+  postWithValidation('/edit-prisoner', editPrisoner.validate(), editPrisoner.submit())
 
   post('/activate-prisoner', prisonerStatus.setStatus('inactive'))
   post('/deactivate-prisoner', prisonerStatus.setStatus('active'))

--- a/server/routes/bookers/booker/index.ts
+++ b/server/routes/bookers/booker/index.ts
@@ -16,8 +16,12 @@ export default function routes(services: Services): Router {
   const postWithValidation = (path: string | string[], validationChain: ValidationChain[], handler: RequestHandler) =>
     router.post(path, ...validationChain, asyncMiddleware(handler))
 
-  const bookerDetails = new BookerDetailsController(services.bookerService, services.prisonerContactsService)
-  const addPrisoner = new AddPrisonerController(services.bookerService)
+  const bookerDetails = new BookerDetailsController(
+    services.bookerService,
+    services.prisonerContactsService,
+    services.prisonService,
+  )
+  const addPrisoner = new AddPrisonerController(services.bookerService, services.prisonService)
   const prisonerStatus = new PrisonerStatusController(services.bookerService)
   const addVisitor = new AddVisitorController(services.bookerService, services.prisonerContactsService)
   const visitorStatus = new VisitorStatusController(services.bookerService)

--- a/server/routes/testutils/testData.ts
+++ b/server/routes/testutils/testData.ts
@@ -355,10 +355,12 @@ export default class TestData {
   static permittedPrisonerDto = ({
     prisonerId = 'A1234BC',
     active = true,
+    prisonCode = 'HEI',
     permittedVisitors = [],
   }: Partial<PermittedPrisonerDto> = {}): PermittedPrisonerDto => ({
     prisonerId,
     active,
+    prisonCode,
     permittedVisitors,
   })
 

--- a/server/services/bookerService.test.ts
+++ b/server/services/bookerService.test.ts
@@ -63,9 +63,18 @@ describe('Booker service', () => {
     describe('addPrisoner', () => {
       it('should add prisoner to booker', async () => {
         bookerRegistryApiClient.addPrisoner.mockResolvedValue(prisoner)
-        const results = await bookerService.addPrisoner('user', booker.reference, prisoner.prisonerId)
+        const results = await bookerService.addPrisoner(
+          'user',
+          booker.reference,
+          prisoner.prisonerId,
+          prisoner.prisonCode,
+        )
 
-        expect(bookerRegistryApiClient.addPrisoner).toHaveBeenCalledWith(booker.reference, prisoner.prisonerId)
+        expect(bookerRegistryApiClient.addPrisoner).toHaveBeenCalledWith(
+          booker.reference,
+          prisoner.prisonerId,
+          prisoner.prisonCode,
+        )
         expect(results).toStrictEqual(prisoner)
       })
     })

--- a/server/services/bookerService.ts
+++ b/server/services/bookerService.ts
@@ -37,12 +37,17 @@ export default class BookerService {
 
   // Prisoner
 
-  async addPrisoner(username: string, bookerReference: string, prisonerId: string): Promise<PermittedPrisonerDto> {
+  async addPrisoner(
+    username: string,
+    bookerReference: string,
+    prisonerId: string,
+    prisonCode: string,
+  ): Promise<PermittedPrisonerDto> {
     const token = await this.hmppsAuthClient.getSystemClientToken(username)
     const bookerRegistryApiClient = this.bookerRegistryApiClientFactory(token)
 
-    const permittedPrisonerDto = await bookerRegistryApiClient.addPrisoner(bookerReference, prisonerId)
-    logger.info(`Prisoner ${prisonerId} added to booker ${bookerReference} by ${username}`)
+    const permittedPrisonerDto = await bookerRegistryApiClient.addPrisoner(bookerReference, prisonerId, prisonCode)
+    logger.info(`Prisoner ${prisonerId} with prison ${prisonCode} added to booker ${bookerReference} by ${username}`)
     return permittedPrisonerDto
   }
 

--- a/server/views/pages/bookers/booker/addPrisoner.njk
+++ b/server/views/pages/bookers/booker/addPrisoner.njk
@@ -1,6 +1,7 @@
 {% extends "partials/layout.njk" %}
 {% from "govuk/components/input/macro.njk" import govukInput %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/select/macro.njk" import govukSelect %}
 
 {% set pageHeaderTitle = "Add a prisoner" %}
 {% set pageTitle = applicationName + " - Manage bookers - " + pageHeaderTitle %}
@@ -22,7 +23,8 @@
 
       {{ govukInput({
           label: {
-            text: "Enter prisoner number"
+            text: "Prisoner number",
+            classes: "govuk-label--s"
           },
           hint: {
             text: "E.g. A1234BC"
@@ -33,7 +35,22 @@
           value: formValues.prisonerNumber,
           autocomplete: "off",
           spellcheck: false,
-          errorMessage: errors | findError('prisonerNumber')
+          errorMessage: errors | findError("prisonerNumber")
+        }) }}
+
+        {{ govukSelect({
+          id: "prisonCode",
+          name: "prisonCode",
+          label: {
+            text: "Prison",
+            classes: "govuk-label--s"
+          },
+          hint: {
+            html: "Select the prisoner's current prison"
+          },
+          items: [{ value: "", text: "Select a prison" }].concat(prisonSelectItems),
+          value: formValues.prisonCode,
+          errorMessage: errors | findError("prisonCode")
         }) }}
 
         {{ govukButton({

--- a/server/views/pages/bookers/booker/details.njk
+++ b/server/views/pages/bookers/booker/details.njk
@@ -36,9 +36,12 @@
       }) }}
 
     {% else %}
-      <p>
+      <p class="govuk-!-margin-bottom-1">
         Prisoner number: <strong data-test="prisoner-number">{{ prisoner.prisonerId }}</strong>
         <span data-test="prisoner-status" class="govuk-!-margin-left-3">{{ activeOrInactiveTag(prisoner.active) }}</span>
+      </p>
+      <p>
+        Prison: <strong data-test="prison-name">{{ prisonName }}</strong>
       </p>
       {% set prisonerAction = "deactivate" if prisoner.active else "activate" %}
       <form action="/bookers/booker/{{ prisonerAction }}-prisoner" method="POST" novalidate>

--- a/server/views/pages/bookers/booker/details.njk
+++ b/server/views/pages/bookers/booker/details.njk
@@ -41,17 +41,28 @@
         <span data-test="prisoner-status" class="govuk-!-margin-left-3">{{ activeOrInactiveTag(prisoner.active) }}</span>
       </p>
       <p>
-        Prison: <strong data-test="prison-name">{{ prisonName }}</strong>
+        Registered prison: <strong data-test="registered-prison-name">{{ prisonName }}</strong>
       </p>
-      {% set prisonerAction = "deactivate" if prisoner.active else "activate" %}
-      <form action="/bookers/booker/{{ prisonerAction }}-prisoner" method="POST" novalidate>
-        <input type="hidden" name="_csrf" value="{{ csrfToken }}">
-        {{ govukButton({
-          text: prisonerAction | capitalize + " prisoner",
-          classes: "govuk-button--secondary",
-          preventDoubleClick: true
-        }) }}
-      </form>
+
+      <div class="govuk-button-group">
+        {% set prisonerAction = "deactivate" if prisoner.active else "activate" %}
+        <form action="/bookers/booker/{{ prisonerAction }}-prisoner" method="POST" novalidate>
+          <input type="hidden" name="_csrf" value="{{ csrfToken }}">
+
+          {{ govukButton({
+            text: "Change registered prison",
+            classes: "govuk-button--secondary",
+            href: "/bookers/booker/edit-prisoner",
+            preventDoubleClick: true
+          }) }}
+
+          {{ govukButton({
+            text: prisonerAction | capitalize + " prisoner",
+            classes: "govuk-button--secondary",
+            preventDoubleClick: true
+          }) }}
+        </form>
+      </div>
 
       <h2 class="govuk-heading-m">Visitors</h2>
       {% if not visitors | length %}

--- a/server/views/pages/bookers/booker/editPrisoner.njk
+++ b/server/views/pages/bookers/booker/editPrisoner.njk
@@ -3,7 +3,7 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/select/macro.njk" import govukSelect %}
 
-{% set pageHeaderTitle = "Add a prisoner" %}
+{% set pageHeaderTitle = "Change prisoner’s registered prison" %}
 {% set pageTitle = applicationName + " - Manage bookers - " + pageHeaderTitle %}
 {% set activePrimaryNav = "bookers" %}
 {% set backLinkHref = "/bookers/booker/details" %}
@@ -16,37 +16,22 @@
 
     <h1 class="govuk-heading-l">{{ pageHeaderTitle }}</h1>
 
-    <p>Add a prisoner to booker <strong>{{ booker.email }}</strong></p>
+    <p>Booker: <strong>{{ booker.email }}</strong></p>
+    <p>Prisoner: <strong>{{ prisoner.prisonerId }}</strong></p>
+    <p>Currently registered prison: <strong>{{ currentPrisonName }}</strong></p>
 
-    <form action="/bookers/booker/add-prisoner" method="POST" novalidate>
+    <form action="/bookers/booker/edit-prisoner" method="POST" novalidate>
       <input type="hidden" name="_csrf" value="{{ csrfToken }}">
-
-      {{ govukInput({
-          label: {
-            text: "Prisoner number",
-            classes: "govuk-label--s"
-          },
-          hint: {
-            text: "E.g. A1234BC"
-          },
-          id: "prisonerNumber",
-          name: "prisonerNumber",
-          classes: "govuk-input--width-10",
-          value: formValues.prisonerNumber,
-          autocomplete: "off",
-          spellcheck: false,
-          errorMessage: errors | findError("prisonerNumber")
-        }) }}
 
         {{ govukSelect({
           id: "prisonCode",
           name: "prisonCode",
           label: {
-            text: "Prison",
-            classes: "govuk-label--s"
+            text: "Change registered prison",
+            classes: "govuk-label--m"
           },
           hint: {
-            text: "Select the prisoner's current prison"
+            text: "Select the prisoner's new prison"
           },
           items: [{ value: "", text: "Select a prison" }].concat(prisonSelectItems),
           value: formValues.prisonCode,
@@ -54,7 +39,7 @@
         }) }}
 
         {{ govukButton({
-          text: "Add prisoner",
+          text: "Change prison",
           attributes: { "data-test": "add-prisoner" },
           preventDoubleClick: true
         }) }}


### PR DESCRIPTION
Update to reflect changes in the API which now require a prisoner and prison entering when adding a prisoner to a booker account.

* To do this a drop-down select component with prison names has been added to the 'Add prisoner' page.
* Allow a prisoner's currently registered prison to be updated - e.g. if the prisoner has been transferred. (Temporary solution until there is a user journey and/or automation to support this.)