### PR TITLE
VB-4197 Fix escaping of user-entered data

### DIFF
--- a/server/views/pages/prisons/categoryGroups/viewCategoryGroups.njk
+++ b/server/views/pages/prisons/categoryGroups/viewCategoryGroups.njk
@@ -46,7 +46,7 @@
       {% for categoryGroup in categoryGroups %}
         {% set rows = (rows.push([
         {
-          html: '<a class="govuk-link--no-visited-state" href="/prisons/' + prison.code + '/category-groups/' + categoryGroup.reference + '">' + categoryGroup.name + "</a>",
+          html: '<a class="govuk-link--no-visited-state" href="/prisons/' + prison.code + '/category-groups/' + categoryGroup.reference + '">' + categoryGroup.name | escape + "</a>",
           attributes: { "data-test": "category-group-name" }
 
         },

--- a/server/views/pages/prisons/configuration/addEditContactDetails.njk
+++ b/server/views/pages/prisons/configuration/addEditContactDetails.njk
@@ -30,7 +30,7 @@
 
         {{ govukInput({
           label: {
-            html: 'Social visits email',
+            text: 'Social visits email',
             classes: 'govuk-label--m'
           },
           id: 'emailAddress',
@@ -44,7 +44,7 @@
 
         {{ govukInput({
           label: {
-            html: 'Social visits telephone',
+            text: 'Social visits telephone',
             classes: 'govuk-label--m'
           },
           id: 'phoneNumber',
@@ -58,7 +58,7 @@
 
         {{ govukInput({
           label: {
-            html: 'Prison web address',
+            text: 'Prison web address',
             classes: 'govuk-label--m'
           },
           id: 'webAddress',

--- a/server/views/pages/prisons/configuration/config.njk
+++ b/server/views/pages/prisons/configuration/config.njk
@@ -96,7 +96,7 @@
                 text: "Prison web address"
               },
               value: {
-                html: '<a class="govuk-link--no-visited-state" href="' + prisonContactDetails.webAddress + '" target="_blank" rel="noopener noreferrer">' + prisonContactDetails.webAddress + "</a>"
+                html: '<a class="govuk-link--no-visited-state" href="' + prisonContactDetails.webAddress + '" target="_blank" rel="noopener noreferrer">' + prisonContactDetails.webAddress | escape + "</a>"
                   if prisonContactDetails.webAddress else "Not set",
                   classes: "test-contact-web"
               }

--- a/server/views/pages/prisons/configuration/editBookingWindow.njk
+++ b/server/views/pages/prisons/configuration/editBookingWindow.njk
@@ -30,7 +30,7 @@
 
         {{ govukInput({
           label: {
-            html: 'Min',
+            text: 'Min',
             classes: 'govuk-label--m'
           },
           hint: {
@@ -47,7 +47,7 @@
 
         {{ govukInput({
           label: {
-            html: 'Max',
+            text: 'Max',
             classes: 'govuk-label--m'
           },
           hint: {

--- a/server/views/pages/prisons/configuration/editVisitorConfig.njk
+++ b/server/views/pages/prisons/configuration/editVisitorConfig.njk
@@ -30,7 +30,7 @@
 
         {{ govukInput({
           label: {
-            html: 'Maximum total visitors',
+            text: 'Maximum total visitors',
             classes: 'govuk-label--m'
           },
           hint: {
@@ -47,7 +47,7 @@
 
         {{ govukInput({
           label: {
-            html: 'Maximum number of adults',
+            text: 'Maximum number of adults',
             classes: 'govuk-label--m'
           },
           hint: {
@@ -64,7 +64,7 @@
 
         {{ govukInput({
           label: {
-            html: 'Maximum number of children',
+            text: 'Maximum number of children',
             classes: 'govuk-label--m'
           },
           hint: {
@@ -81,7 +81,7 @@
 
         {{ govukInput({
           label: {
-            html: 'Adult age threshold',
+            text: 'Adult age threshold',
             classes: 'govuk-label--m'
           },
           hint: {

--- a/server/views/pages/prisons/incentiveGroups/addIncentiveGroup.njk
+++ b/server/views/pages/prisons/incentiveGroups/addIncentiveGroup.njk
@@ -40,7 +40,7 @@
 
         {{ govukInput({
           label: {
-            html: 'Incentive level group name',
+            text: 'Incentive level group name',
             classes: 'govuk-label--m'
           },
           id: 'name',

--- a/server/views/pages/prisons/incentiveGroups/viewIncentiveGroups.njk
+++ b/server/views/pages/prisons/incentiveGroups/viewIncentiveGroups.njk
@@ -45,7 +45,7 @@
       {% for incentiveLevelGroup in incentiveGroups %}
         {% set rows = (rows.push([
         {
-          html: '<a class="govuk-link--no-visited-state" href="/prisons/' + prison.code + '/incentive-groups/' + incentiveLevelGroup.reference + '">' + incentiveLevelGroup.name + "</a>",
+          html: '<a class="govuk-link--no-visited-state" href="/prisons/' + prison.code + '/incentive-groups/' + incentiveLevelGroup.reference + '">' + incentiveLevelGroup.name | escape + "</a>",
           attributes: { "data-test": "incentive-group-name" }
         },
         {

--- a/server/views/pages/prisons/locationGroups/addLocationGroup.njk
+++ b/server/views/pages/prisons/locationGroups/addLocationGroup.njk
@@ -27,7 +27,7 @@
 
           {{ govukInput({
             label: {
-              html: "Location group name",
+              text: "Location group name",
               classes: "govuk-label--m"
             },
             id: "name",

--- a/server/views/pages/prisons/locationGroups/editLocationGroup.njk
+++ b/server/views/pages/prisons/locationGroups/editLocationGroup.njk
@@ -27,7 +27,7 @@
 
           {{ govukInput({
             label: {
-              html: "Location group name",
+              text: "Location group name",
               classes: "govuk-label--m"
             },
             id: "name",

--- a/server/views/pages/prisons/locationGroups/viewLocationGroups.njk
+++ b/server/views/pages/prisons/locationGroups/viewLocationGroups.njk
@@ -45,7 +45,7 @@
       {% for locationGroup in locationGroups %}
         {% set rows = (rows.push([
         {
-          html: '<a class="govuk-link--no-visited-state" href="/prisons/' + prison.code + '/location-groups/' + locationGroup.reference + '">' + locationGroup.name + "</a>",
+          html: '<a class="govuk-link--no-visited-state" href="/prisons/' + prison.code + '/location-groups/' + locationGroup.reference + '">' + locationGroup.name | escape + "</a>",
           attributes: { "data-test": "location-group-name" }
         },
         {

--- a/server/views/pages/prisons/prisons.njk
+++ b/server/views/pages/prisons/prisons.njk
@@ -28,7 +28,7 @@
           attributes: { "data-test": "prison-code" }
         },
         {
-          html: '<a class="govuk-link--no-visited-state" href="/prisons/' + prison.code + '/session-templates">' + prison.name + "</a>",
+          html: '<a class="govuk-link--no-visited-state" href="/prisons/' + prison.code + '/session-templates">' + prison.name | escape + "</a>",
           attributes: { "data-test": "prison-name" }
         },
         {

--- a/server/views/pages/prisons/sessionTemplates/viewSessionTemplates.njk
+++ b/server/views/pages/prisons/sessionTemplates/viewSessionTemplates.njk
@@ -97,7 +97,7 @@
               {%- set rows = (rows.push([
                 {
                   html: '<a class="govuk-link--no-visited-state" href="/prisons/' + prison.code + '/session-templates/' + sessionTemplate.reference + '">'
-                    + sessionTemplate.name + "</a>",
+                    + sessionTemplate.name | escape + "</a>",
                   attributes: { "data-test": "template-name" }
                 },
                 {


### PR DESCRIPTION
Use Nunjuck's `escape` filter where appropriate and for GOVUK macros, use `text` instead of `html` attribute where possible (to benefit from auto-escaping with the former).