### PR TITLE
VB-5081 Add default room name for new session templates

### DIFF
--- a/integration_tests/pages/prisons/sessionTemplates/addSessionTemplate.ts
+++ b/integration_tests/pages/prisons/sessionTemplates/addSessionTemplate.ts
@@ -50,7 +50,10 @@ export default class AddSessionTemplatePage extends Page {
   }
 
   enterVisitRoom = (room: string): void => {
-    cy.get('#visitRoom').type(room)
+    cy.get('#visitRoom').then(input => {
+      cy.wrap(input).clear()
+      cy.wrap(input).type(room)
+    })
   }
 
   addCategoryGroups = (categoryGroups: CategoryGroup[]): void => {

--- a/server/views/pages/prisons/sessionTemplates/addSessionTemplate.njk
+++ b/server/views/pages/prisons/sessionTemplates/addSessionTemplate.njk
@@ -277,7 +277,7 @@
           classes: "govuk-!-width-one-third",
           id: "visitRoom",
           name: "visitRoom",
-          value: formValues.visitRoom,
+          value: formValues.visitRoom | default("Visits Hall"),
           autocomplete: "off",
           errorMessage: errors | findError('visitRoom')
         }) }}


### PR DESCRIPTION
Default "Visit room" input to be "Visits Hall" when creating a new visit session template.