### PR TITLE
VB5522 Booker management: look up a booker by email or reference

### DIFF
--- a/integration_tests/e2e/bookers/bookerManagement.cy.ts
+++ b/integration_tests/e2e/bookers/bookerManagement.cy.ts
@@ -36,8 +36,9 @@ context('Booker management', () => {
 
     // Search for booker
     cy.task('stubGetBookersByEmail', { email: booker.email, bookers: [booker] })
+    cy.task('stubGetBookerByReference', { booker })
     cy.task('stubGetSocialContacts', { prisonerId: prisoner.prisonerId, contacts: [], approvedOnly: false })
-    searchForBookerPage.enterBookerEmail(booker.email)
+    searchForBookerPage.enterBookerSearchTerm(booker.email)
     searchForBookerPage.search()
 
     // Booker details page
@@ -52,7 +53,7 @@ context('Booker management', () => {
     addPrisonerPage.enterPrisonerNumber(prisoner.prisonerId)
     addPrisonerPage.selectPrison(prisoner.prisonCode)
     cy.task('stubCreateBookerPrisoner', { booker, prisoner })
-    cy.task('stubGetBookersByEmail', { email: bookerWithPrisoner.email, bookers: [bookerWithPrisoner] })
+    cy.task('stubGetBookerByReference', { booker: bookerWithPrisoner })
     cy.task('stubGetSocialContacts', { prisonerId: prisoner.prisonerId, contacts: [contact], approvedOnly: false })
     addPrisonerPage.addPrisoner()
 
@@ -67,10 +68,7 @@ context('Booker management', () => {
     const addVisitorPage = Page.verifyOnPage(AddVisitorPage)
     addVisitorPage.selectVisitorById(contact.personId)
     cy.task('stubCreateBookerPrisonerVisitor', { booker, prisoner, contact })
-    cy.task('stubGetBookersByEmail', {
-      email: bookerWithPrisonerAndContacts.email,
-      bookers: [bookerWithPrisonerAndContacts],
-    })
+    cy.task('stubGetBookerByReference', { booker: bookerWithPrisonerAndContacts })
     addVisitorPage.addVisitor()
 
     // Booker details - visitor added
@@ -89,8 +87,9 @@ context('Booker management', () => {
       email: bookerWithPrisonerAndContacts.email,
       bookers: [bookerWithPrisonerAndContacts],
     })
+    cy.task('stubGetBookerByReference', { booker: bookerWithPrisonerAndContacts })
     cy.task('stubGetSocialContacts', { prisonerId: prisoner.prisonerId, contacts: [contact], approvedOnly: false })
-    searchForBookerPage.enterBookerEmail(booker.email)
+    searchForBookerPage.enterBookerSearchTerm(booker.email)
     searchForBookerPage.search()
 
     // Booker details page - prisoner and visitors present
@@ -102,7 +101,7 @@ context('Booker management', () => {
 
     // Clear booker details
     cy.task('stubClearBookerDetails', bookerWithPrisonerAndContacts)
-    cy.task('stubGetBookersByEmail', { email: booker.email, bookers: [booker] })
+    cy.task('stubGetBookerByReference', { booker })
     bookerDetailsPage.clearBookerDetails()
 
     // Booker details page - no prisoner set

--- a/integration_tests/mockApis/bookerRegistry.ts
+++ b/integration_tests/mockApis/bookerRegistry.ts
@@ -4,6 +4,20 @@ import { BookerDto, PermittedPrisonerDto } from '../../server/data/bookerRegistr
 import { ContactDto } from '../../server/data/prisonerContactRegistryApiTypes'
 
 export default {
+  stubGetBookerByReference: ({ booker }: { booker: BookerDto }): SuperAgentRequest => {
+    return stubFor({
+      request: {
+        method: 'GET',
+        url: `/bookerRegistry/public/booker/config/${booker.reference}`,
+      },
+      response: {
+        status: 200,
+        headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+        jsonBody: booker,
+      },
+    })
+  },
+
   stubGetBookersByEmail: ({ email, bookers }: { email: string; bookers: BookerDto[] }): SuperAgentRequest => {
     return stubFor({
       request: {

--- a/integration_tests/pages/bookers/searchForBooker.ts
+++ b/integration_tests/pages/bookers/searchForBooker.ts
@@ -5,8 +5,8 @@ export default class SearchForBookerPage extends Page {
     super('Search for a booker account')
   }
 
-  enterBookerEmail = (email: string): void => {
-    cy.get('#search').type(email)
+  enterBookerSearchTerm = (search: string): void => {
+    cy.get('#search').type(search)
   }
 
   search = (): void => {

--- a/integration_tests/pages/bookers/searchForBooker.ts
+++ b/integration_tests/pages/bookers/searchForBooker.ts
@@ -2,11 +2,11 @@ import Page from '../page'
 
 export default class SearchForBookerPage extends Page {
   constructor() {
-    super('Search for a booker')
+    super('Search for a booker account')
   }
 
   enterBookerEmail = (email: string): void => {
-    cy.get('#booker').type(email)
+    cy.get('#search').type(email)
   }
 
   search = (): void => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,8 @@
         "passport-oauth2": "^1.8.0",
         "redis": "^5.5.6",
         "superagent": "^10.2.1",
-        "url-value-parser": "^2.2.0"
+        "url-value-parser": "^2.2.0",
+        "validator": "^13.15.15"
       },
       "devDependencies": {
         "@ministryofjustice/eslint-config-hmpps": "^0.0.1-beta.2",
@@ -52,6 +53,7 @@
         "@types/passport-oauth2": "^1.4.17",
         "@types/superagent": "^8.1.9",
         "@types/supertest": "^6.0.3",
+        "@types/validator": "^13.15.2",
         "@typescript-eslint/eslint-plugin": "^8.34.1",
         "@typescript-eslint/parser": "^8.34.1",
         "audit-ci": "^7.1.0",
@@ -2925,6 +2927,13 @@
         "@types/superagent": "^8.1.0"
       }
     },
+    "node_modules/@types/validator": {
+      "version": "13.15.2",
+      "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.15.2.tgz",
+      "integrity": "sha512-y7pa/oEJJ4iGYBxOpfAKn5b9+xuihvzDVnC/OSvlVnGxVg0pOqmjiMafiJ1KVNQEaPZf9HsEp5icEwGg8uIe5Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/yargs": {
       "version": "17.0.33",
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.33.tgz",
@@ -5721,9 +5730,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.168",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.168.tgz",
-      "integrity": "sha512-RUNQmFLNIWVW6+z32EJQ5+qx8ci6RGvdtDC0Ls+F89wz6I2AthpXF0w0DIrn2jpLX0/PU9ZCo+Qp7bg/EckJmA==",
+      "version": "1.5.169",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.169.tgz",
+      "integrity": "sha512-q7SQx6mkLy0GTJK9K9OiWeaBMV4XQtBSdf6MJUzDB/H/5tFXfIiX38Lci1Kl6SsgiEhz1SQI1ejEOU5asWEhwQ==",
       "dev": true,
       "license": "ISC"
     },
@@ -6266,9 +6275,9 @@
       }
     },
     "node_modules/eslint-plugin-prettier": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.4.1.tgz",
-      "integrity": "sha512-9dF+KuU/Ilkq27A8idRP7N2DH8iUR6qXcjF3FR2wETY21PZdBrIjwCau8oboyGj9b7etWmTGEeM8e7oOed6ZWg==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.5.0.tgz",
+      "integrity": "sha512-8qsOYwkkGrahrgoUv76NZi23koqXOGiiEzXMrT8Q7VcYaUISR+5MorIUxfWqYXN0fN/31WbSrxCxFkVQ43wwrA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6662,6 +6671,15 @@
       },
       "engines": {
         "node": ">= 8.0.0"
+      }
+    },
+    "node_modules/express-validator/node_modules/validator": {
+      "version": "13.12.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.12.0.tgz",
+      "integrity": "sha512-c1Q0mCiPlgdTVVVIJIrBuxNicYE+t/7oKeI9MWLj3fh/uq2Pxh/3eeWbVZ4OcGW1TUf53At0njHw5SMdA3tmMg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/express/node_modules/mime-types": {
@@ -13569,9 +13587,9 @@
       }
     },
     "node_modules/validator": {
-      "version": "13.12.0",
-      "resolved": "https://registry.npmjs.org/validator/-/validator-13.12.0.tgz",
-      "integrity": "sha512-c1Q0mCiPlgdTVVVIJIrBuxNicYE+t/7oKeI9MWLj3fh/uq2Pxh/3eeWbVZ4OcGW1TUf53At0njHw5SMdA3tmMg==",
+      "version": "13.15.15",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.15.15.tgz",
+      "integrity": "sha512-BgWVbCI72aIQy937xbawcs+hrVaN/CZ2UwutgaJ36hGqRrLNM+f5LUT/YPRbo8IV/ASeFzXszezV+y2+rq3l8A==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.10"

--- a/package.json
+++ b/package.json
@@ -111,7 +111,8 @@
     "passport-oauth2": "^1.8.0",
     "redis": "^5.5.6",
     "superagent": "^10.2.1",
-    "url-value-parser": "^2.2.0"
+    "url-value-parser": "^2.2.0",
+    "validator": "^13.15.15"
   },
   "devDependencies": {
     "@ministryofjustice/eslint-config-hmpps": "^0.0.1-beta.2",
@@ -133,6 +134,7 @@
     "@types/supertest": "^6.0.3",
     "@typescript-eslint/eslint-plugin": "^8.34.1",
     "@typescript-eslint/parser": "^8.34.1",
+    "@types/validator": "^13.15.2",
     "audit-ci": "^7.1.0",
     "cheerio": "^1.1.0",
     "concurrently": "^9.1.2",

--- a/server/constants/constants.ts
+++ b/server/constants/constants.ts
@@ -1,0 +1,2 @@
+// eslint-disable-next-line import/prefer-default-export
+export const BOOKER_REFERENCE_REGEX = /^[a-z]{4}-[a-z]{4}-[a-z]{4}$/

--- a/server/data/bookerRegistryApiClient.test.ts
+++ b/server/data/bookerRegistryApiClient.test.ts
@@ -27,6 +27,18 @@ describe('bookerRegistryApiClient', () => {
   })
 
   describe('Booker', () => {
+    describe('getBookerByReference', () => {
+      it('should get booker details for given reference', async () => {
+        fakeBookerRegistryApi
+          .get(`/public/booker/config/${booker.reference}`)
+          .matchHeader('authorization', `Bearer ${token}`)
+          .reply(200, booker)
+
+        const output = await bookerRegistryApiClient.getBookerByReference(booker.reference)
+        expect(output).toStrictEqual(booker)
+      })
+    })
+
     describe('getBookersByEmail', () => {
       it('should get booker details for given email', async () => {
         fakeBookerRegistryApi

--- a/server/data/bookerRegistryApiClient.ts
+++ b/server/data/bookerRegistryApiClient.ts
@@ -16,6 +16,10 @@ export default class BookerRegistryApiClient {
 
   // Booker
 
+  async getBookerByReference(reference: string): Promise<BookerDto> {
+    return this.restClient.get({ path: `/public/booker/config/${reference}` })
+  }
+
   async getBookersByEmail(email: string): Promise<BookerDto[]> {
     return this.restClient.get({ path: `/public/booker/config/email/${email}` })
   }

--- a/server/routes/bookers/booker/bookerDetailsController.test.ts
+++ b/server/routes/bookers/booker/bookerDetailsController.test.ts
@@ -41,7 +41,7 @@ describe('Booker details', () => {
       })
       const booker = TestData.bookerDto({ permittedPrisoners: [prisoner] })
       sessionData.booker = booker
-      bookerService.getBookersByEmail.mockResolvedValue([booker])
+      bookerService.getBookerByReference.mockResolvedValue(booker)
       prisonerContactsService.getSocialContacts.mockResolvedValue([contact])
 
       return request(app)
@@ -71,7 +71,7 @@ describe('Booker details', () => {
           expect($('[data-test=visitor-restrictions-1]').text().trim()).toBe('None')
           expect($('[data-test=visitor-status-1]').text().trim()).toBe('Active')
 
-          expect(bookerService.getBookersByEmail).toHaveBeenCalledWith('user1', booker.email)
+          expect(bookerService.getBookerByReference).toHaveBeenCalledWith('user1', booker.reference)
           expect(prisonerContactsService.getSocialContacts).toHaveBeenCalledWith({
             username: 'user1',
             prisonerId: prisoner.prisonerId,

--- a/server/routes/bookers/booker/bookerDetailsController.ts
+++ b/server/routes/bookers/booker/bookerDetailsController.ts
@@ -20,10 +20,9 @@ export default class BookerDetailsController {
 
   public view(): RequestHandler {
     return async (req, res) => {
-      const { email } = req.session.booker
+      const { reference } = req.session.booker
 
-      // TODO handle more than one booker record for an email address
-      const booker = (await this.bookerService.getBookersByEmail(res.locals.user.username, email))[0]
+      const booker = await this.bookerService.getBookerByReference(res.locals.user.username, reference)
       req.session.booker = booker
 
       const prisoner = booker.permittedPrisoners[0] ?? undefined

--- a/server/routes/bookers/booker/editPrisonerController.ts
+++ b/server/routes/bookers/booker/editPrisonerController.ts
@@ -89,8 +89,7 @@ export default class EditPrisonerController {
 
         // clear session and re-load data
         delete req.session.booker
-        // TODO handle more than one booker record for an email address
-        req.session.booker = (await this.bookerService.getBookersByEmail(res.locals.user.username, booker.email)).at(0)
+        req.session.booker = await this.bookerService.getBookerByReference(res.locals.user.username, booker.reference)
 
         req.flash('messages', {
           variant: 'success',

--- a/server/routes/bookers/bookerSearchController.test.ts
+++ b/server/routes/bookers/bookerSearchController.test.ts
@@ -35,12 +35,12 @@ describe('Search for a booker', () => {
           expect($('.moj-primary-navigation__item').length).toBe(3)
           expect($('.moj-primary-navigation__link[aria-current]').attr('href')).toBe('/bookers')
 
-          expect($('h1').text().trim()).toBe('Search for a booker')
+          expect($('h1').text().trim()).toBe('Search for a booker account')
 
           expect($('.moj-alert').length).toBe(0)
           expect($('.govuk-error-summary').length).toBe(0)
 
-          expect($('input[name=booker]').length).toBe(1)
+          expect($('input[name=search]').length).toBe(1)
           expect($('[data-test=submit]').text().trim()).toBe('Search')
         })
     })
@@ -49,14 +49,14 @@ describe('Search for a booker', () => {
       const error: FieldValidationError = {
         type: 'field',
         location: 'body',
-        path: 'booker',
+        path: 'search',
         value: 'invalid',
         msg: 'Validation error',
       }
       const message: MoJAlert = {
         variant: 'information',
-        title: 'Booker message',
-        text: 'Booker message',
+        title: 'Search message',
+        text: 'Search message',
       }
 
       flashData = {
@@ -68,11 +68,11 @@ describe('Search for a booker', () => {
         .expect('Content-Type', /html/)
         .expect(res => {
           const $ = cheerio.load(res.text)
-          expect($('h1').text().trim()).toBe('Search for a booker')
+          expect($('h1').text().trim()).toBe('Search for a booker account')
 
           expect($('.moj-alert__content').text()).toBe(message.text)
           expect($('.govuk-error-summary').text()).toContain(error.msg)
-          expect($('#booker-error').text()).toContain(error.msg)
+          expect($('#search-error').text()).toContain(error.msg)
         })
     })
   })
@@ -85,7 +85,7 @@ describe('Search for a booker', () => {
 
       return request(app)
         .post('/bookers/search')
-        .send({ booker: booker.email })
+        .send({ search: booker.email })
         .expect(302)
         .expect('location', '/bookers/booker/details')
         .expect(() => {
@@ -99,12 +99,12 @@ describe('Search for a booker', () => {
 
       return request(app)
         .post('/bookers/search')
-        .send({ booker: booker.email })
+        .send({ search: booker.email })
         .expect(302)
         .expect('location', '/bookers')
         .expect(() => {
           expect(flashProvider).toHaveBeenCalledTimes(2)
-          expect(flashProvider).toHaveBeenCalledWith('formValues', { booker: booker.email })
+          expect(flashProvider).toHaveBeenCalledWith('formValues', { search: booker.email })
           expect(flashProvider).toHaveBeenCalledWith('messages', <MoJAlert>{
             variant: 'information',
             title: 'No booker found',
@@ -118,19 +118,19 @@ describe('Search for a booker', () => {
       const expectedError: FieldValidationError = {
         type: 'field',
         location: 'body',
-        path: 'booker',
+        path: 'search',
         value: 'INVALID',
         msg: 'Enter a valid email address',
       }
 
       return request(app)
         .post('/bookers/search')
-        .send({ booker: 'INVALID' })
+        .send({ search: 'INVALID' })
         .expect(302)
         .expect('location', '/bookers')
         .expect(() => {
           expect(flashProvider).toHaveBeenCalledTimes(2)
-          expect(flashProvider).toHaveBeenCalledWith('formValues', { booker: 'INVALID' })
+          expect(flashProvider).toHaveBeenCalledWith('formValues', { search: 'INVALID' })
           expect(flashProvider).toHaveBeenCalledWith('errors', [expectedError])
           expect(bookerService.getBookersByEmail).not.toHaveBeenCalled()
         })

--- a/server/routes/bookers/bookerSearchController.ts
+++ b/server/routes/bookers/bookerSearchController.ts
@@ -3,12 +3,12 @@ import { ValidationChain, body, validationResult } from 'express-validator'
 import { BookerService } from '../../services'
 import { responseErrorToFlashMessages } from '../../utils/utils'
 
-export default class BookersController {
+export default class BookerSearchController {
   public constructor(private readonly bookerService: BookerService) {}
 
   public view(): RequestHandler {
     return async (req, res) => {
-      return res.render('pages/bookers/bookers', {
+      return res.render('pages/bookers/search', {
         errors: req.flash('errors'),
         formValues: req.flash('formValues')?.[0] || {},
         messages: req.flash('messages'),
@@ -16,7 +16,7 @@ export default class BookersController {
     }
   }
 
-  public search(): RequestHandler {
+  public submit(): RequestHandler {
     return async (req, res) => {
       delete req.session.booker
 
@@ -26,7 +26,7 @@ export default class BookersController {
         req.flash('formValues', req.body)
         return res.redirect('/bookers')
       }
-      const { booker: email }: { booker: string } = req.body
+      const { search: email }: { search: string } = req.body
 
       try {
         // TODO handle more than one booker record for an email address
@@ -53,6 +53,6 @@ export default class BookersController {
   }
 
   public validate(): ValidationChain[] {
-    return [body('booker', 'Enter a valid email address').trim().isEmail()]
+    return [body('search', 'Enter a valid email address').trim().isEmail()]
   }
 }

--- a/server/routes/bookers/index.ts
+++ b/server/routes/bookers/index.ts
@@ -1,6 +1,6 @@
 import { RequestHandler, Router } from 'express'
 import { ValidationChain } from 'express-validator'
-import BookersController from './bookersController'
+import BookerSearchController from './bookerSearchController'
 import { Services } from '../../services'
 import bookerRoutes from './booker'
 
@@ -11,10 +11,10 @@ export default function routes(services: Services): Router {
   const postWithValidation = (path: string | string[], validationChain: ValidationChain[], handler: RequestHandler) =>
     router.post(path, ...validationChain, handler)
 
-  const bookers = new BookersController(services.bookerService)
+  const bookerSearch = new BookerSearchController(services.bookerService)
 
-  get('/bookers', bookers.view())
-  postWithValidation('/bookers/search', bookers.validate(), bookers.search())
+  get('/bookers', bookerSearch.view())
+  postWithValidation('/bookers/search', bookerSearch.validate(), bookerSearch.submit())
 
   router.use('/bookers/booker', bookerRoutes(services))
 

--- a/server/services/bookerService.test.ts
+++ b/server/services/bookerService.test.ts
@@ -1,7 +1,6 @@
 import TestData from '../routes/testutils/testData'
 import { createMockBookerRegistryApiClient, createMockHmppsAuthClient } from '../data/testutils/mocks'
 import BookerService from './bookerService'
-import { BookerDto } from '../data/bookerRegistryApiTypes'
 
 const token = 'some token'
 
@@ -30,7 +29,7 @@ describe('Booker service', () => {
 
   describe('Booker', () => {
     describe('getBookerByReference', () => {
-      it('should get booker details given reference', async () => {
+      it('should get booker details given booker reference', async () => {
         bookerRegistryApiClient.getBookerByReference.mockResolvedValue(booker)
         const results = await bookerService.getBookerByReference('user', booker.reference)
 
@@ -39,28 +38,35 @@ describe('Booker service', () => {
       })
     })
 
-    describe('getBookersByEmail', () => {
-      it('should get booker details given email address', async () => {
-        bookerRegistryApiClient.getBookersByEmail.mockResolvedValue([booker])
-        const results = await bookerService.getBookersByEmail('user', booker.email)
+    describe('getBookersByEmailOrReference', () => {
+      describe('By email', () => {
+        it('should get booker details given email address', async () => {
+          bookerRegistryApiClient.getBookersByEmail.mockResolvedValue([booker])
+          const results = await bookerService.getBookersByEmailOrReference('user', booker.email)
 
-        expect(bookerRegistryApiClient.getBookersByEmail).toHaveBeenCalledWith(booker.email)
-        expect(results).toStrictEqual([booker])
+          expect(bookerRegistryApiClient.getBookersByEmail).toHaveBeenCalledWith(booker.email)
+          expect(bookerRegistryApiClient.getBookerByReference).not.toHaveBeenCalled()
+          expect(results).toStrictEqual([booker])
+        })
+
+        it('should throw an error if API returns more than one booker for an email', async () => {
+          bookerRegistryApiClient.getBookersByEmail.mockResolvedValue([booker, booker])
+          await expect(bookerService.getBookersByEmailOrReference('user', booker.email)).rejects.toThrow()
+
+          expect(bookerRegistryApiClient.getBookersByEmail).toHaveBeenCalledWith(booker.email)
+          expect(bookerRegistryApiClient.getBookerByReference).not.toHaveBeenCalled()
+        })
       })
 
-      it('should handle API returning single booker instead of array', async () => {
-        bookerRegistryApiClient.getBookersByEmail.mockResolvedValue(booker as unknown as BookerDto[])
-        const results = await bookerService.getBookersByEmail('user', booker.email)
+      describe('By reference', () => {
+        it('should get booker details given reference', async () => {
+          bookerRegistryApiClient.getBookerByReference.mockResolvedValue(booker)
+          const results = await bookerService.getBookersByEmailOrReference('user', booker.reference)
 
-        expect(bookerRegistryApiClient.getBookersByEmail).toHaveBeenCalledWith(booker.email)
-        expect(results).toStrictEqual([booker])
-      })
-
-      it('should throw an error if API returns more than one booker for an email', async () => {
-        bookerRegistryApiClient.getBookersByEmail.mockResolvedValue([booker, booker])
-        await expect(bookerService.getBookersByEmail('user', booker.email)).rejects.toThrow()
-
-        expect(bookerRegistryApiClient.getBookersByEmail).toHaveBeenCalledWith(booker.email)
+          expect(bookerRegistryApiClient.getBookerByReference).toHaveBeenCalledWith(booker.reference)
+          expect(bookerRegistryApiClient.getBookersByEmail).not.toHaveBeenCalled()
+          expect(results).toStrictEqual([booker])
+        })
       })
     })
 

--- a/server/services/bookerService.test.ts
+++ b/server/services/bookerService.test.ts
@@ -29,6 +29,16 @@ describe('Booker service', () => {
   })
 
   describe('Booker', () => {
+    describe('getBookerByReference', () => {
+      it('should get booker details given reference', async () => {
+        bookerRegistryApiClient.getBookerByReference.mockResolvedValue(booker)
+        const results = await bookerService.getBookerByReference('user', booker.reference)
+
+        expect(bookerRegistryApiClient.getBookerByReference).toHaveBeenCalledWith(booker.reference)
+        expect(results).toStrictEqual(booker)
+      })
+    })
+
     describe('getBookersByEmail', () => {
       it('should get booker details given email address', async () => {
         bookerRegistryApiClient.getBookersByEmail.mockResolvedValue([booker])

--- a/server/services/bookerService.ts
+++ b/server/services/bookerService.ts
@@ -10,6 +10,13 @@ export default class BookerService {
 
   // Booker
 
+  async getBookerByReference(username: string, reference: string): Promise<BookerDto> {
+    const token = await this.hmppsAuthClient.getSystemClientToken(username)
+    const bookerRegistryApiClient = this.bookerRegistryApiClientFactory(token)
+
+    return bookerRegistryApiClient.getBookerByReference(reference)
+  }
+
   async getBookersByEmail(username: string, email: string): Promise<BookerDto[]> {
     const token = await this.hmppsAuthClient.getSystemClientToken(username)
     const bookerRegistryApiClient = this.bookerRegistryApiClientFactory(token)

--- a/server/services/bookerService.ts
+++ b/server/services/bookerService.ts
@@ -17,16 +17,15 @@ export default class BookerService {
     return bookerRegistryApiClient.getBookerByReference(reference)
   }
 
-  async getBookersByEmail(username: string, email: string): Promise<BookerDto[]> {
+  async getBookersByEmailOrReference(username: string, search: string): Promise<BookerDto[]> {
     const token = await this.hmppsAuthClient.getSystemClientToken(username)
     const bookerRegistryApiClient = this.bookerRegistryApiClientFactory(token)
 
-    const bookers = await bookerRegistryApiClient.getBookersByEmail(email)
+    const isEmail = search.indexOf('@') >= 0
 
-    // TODO remove when API change for return array of bookers is in prod
-    if (!Array.isArray(bookers)) {
-      return [bookers]
-    }
+    const bookers = isEmail
+      ? await bookerRegistryApiClient.getBookersByEmail(search)
+      : [await bookerRegistryApiClient.getBookerByReference(search)]
 
     // TODO Handle more than one booker record for an email
     if (bookers.length > 1) {

--- a/server/views/pages/bookers/search.njk
+++ b/server/views/pages/bookers/search.njk
@@ -2,7 +2,7 @@
 {% from "govuk/components/input/macro.njk" import govukInput %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
-{% set pageHeaderTitle = "Search for a booker" %}
+{% set pageHeaderTitle = "Search for a booker account" %}
 {% set pageTitle = applicationName + " - Manage bookers " + pageHeaderTitle %}
 {% set activePrimaryNav = "bookers" %}
 
@@ -10,26 +10,27 @@
 {{ super() }}
 
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-full">
-
-    <h1 class="govuk-heading-l">{{ pageHeaderTitle }}</h1>
-
-    <p>Search for an existing booker.</p>
+  <div class="govuk-grid-column-two-thirds">
 
     <form action="/bookers/search" method="POST" novalidate>
       <input type="hidden" name="_csrf" value="{{ csrfToken }}">
 
       {{ govukInput({
           label: {
-            text: "Enter booker's email address"
+            text: pageHeaderTitle,
+            classes: "govuk-label--l",
+            isPageHeading: true
           },
-          id: "booker",
-          name: "booker",
-          classes: "govuk-input--width-20",
-          value: formValues.booker,
+          hint: {
+            text: "Search for an existing booker. You can search by email address or booker reference."
+          },
+          id: "search",
+          name: "search",
+          classes: "govuk-!-width-two-thirds",
+          value: formValues.search,
           autocomplete: "off",
           spellcheck: false,
-          errorMessage: errors | findError('booker')
+          errorMessage: errors | findError("search")
         }) }}
 
         {{ govukButton({


### PR DESCRIPTION
Previously a booker could only be looked up by email address. This change allows either an email or booker reference to be used. Search page and validation updated accordingly.