### PR TITLE
Booker management: fix async bug when changing prisoner's registered prison

### DIFF
--- a/server/routes/bookers/booker/editPrisonerController.ts
+++ b/server/routes/bookers/booker/editPrisonerController.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-await-in-loop */
 import { RequestHandler } from 'express'
 import { ValidationChain, body, validationResult } from 'express-validator'
 import { BookerService, PrisonService } from '../../../services'
@@ -87,24 +88,23 @@ export default class EditPrisonerController {
     // Clear booker details before re-adding all prisoners
     await this.bookerService.clearBookerDetails(username, booker.reference)
 
-    booker.permittedPrisoners.forEach(async prisoner => {
+    for (const prisoner of booker.permittedPrisoners) {
       // re-add prisoner
       await this.bookerService.addPrisoner(username, booker.reference, prisoner.prisonerId, prisoner.prisonCode)
-
       // defaults to creating 'active' so check if necessary to deactivate
       if (!prisoner.active) {
         await this.bookerService.deactivatePrisoner(username, booker.reference, prisoner.prisonerId)
       }
 
       // re-add visitors
-      prisoner.permittedVisitors.forEach(async visitor => {
+      for (const visitor of prisoner.permittedVisitors) {
         await this.bookerService.addVisitor(username, booker.reference, prisoner.prisonerId, visitor.visitorId)
 
         // defaults to creating 'active' so check if necessary to deactivate
         if (!visitor.active) {
           await this.bookerService.deactivateVisitor(username, booker.reference, prisoner.prisonerId, visitor.visitorId)
         }
-      })
-    })
+      }
+    }
   }
 }


### PR DESCRIPTION
Use `for ... of` instead of `forEach()` loop because latter [expects a synchronous function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/forEach#description).

(This is a fix to code that is temporary anyway: it will be going when new API endpoint in place to update a prisoner's prison directly rather than clearing details and re-adding.)