### PR TITLE
Booker management: show visitors without date of birth entered

### DIFF
--- a/integration_tests/e2e/bookers/bookerManagement.cy.ts
+++ b/integration_tests/e2e/bookers/bookerManagement.cy.ts
@@ -38,7 +38,7 @@ context('Booker management', () => {
     // Search for booker
     cy.task('stubGetBookersByEmail', { email: booker.email, bookers: [booker] })
     cy.task('stubGetBookerByReference', { booker })
-    cy.task('stubGetSocialContacts', { prisonerId: prisoner.prisonerId, contacts: [], approvedOnly: false })
+    cy.task('stubGetAllSocialContacts', { prisonerId: prisoner.prisonerId, contacts: [] })
     searchForBookerPage.enterBookerSearchTerm(booker.email)
     searchForBookerPage.search()
 
@@ -55,7 +55,7 @@ context('Booker management', () => {
     addPrisonerPage.selectPrison(prisoner.prisonCode)
     cy.task('stubCreateBookerPrisoner', { booker, prisoner })
     cy.task('stubGetBookerByReference', { booker: bookerWithPrisoner })
-    cy.task('stubGetSocialContacts', { prisonerId: prisoner.prisonerId, contacts: [contact], approvedOnly: false })
+    cy.task('stubGetAllSocialContacts', { prisonerId: prisoner.prisonerId, contacts: [contact] })
     addPrisonerPage.addPrisoner()
 
     // Booker details - prisoner added
@@ -72,7 +72,7 @@ context('Booker management', () => {
     prisonerDetailsPage.prisonName().contains('Hewell (HMP)')
 
     // Add visitor
-    cy.task('stubGetSocialContacts', { prisonerId: prisoner.prisonerId, contacts: [contact], approvedOnly: true })
+    cy.task('stubGetApprovedSocialContacts', { prisonerId: prisoner.prisonerId, contacts: [contact] })
     prisonerDetailsPage.addVisitor()
     const addVisitorPage = Page.verifyOnPage(AddVisitorPage)
     addVisitorPage.selectVisitorById(contact.personId)
@@ -97,7 +97,7 @@ context('Booker management', () => {
       bookers: [bookerWithPrisonerAndContacts],
     })
     cy.task('stubGetBookerByReference', { booker: bookerWithPrisonerAndContacts })
-    cy.task('stubGetSocialContacts', { prisonerId: prisoner.prisonerId, contacts: [contact], approvedOnly: false })
+    cy.task('stubGetAllSocialContacts', { prisonerId: prisoner.prisonerId, contacts: [contact] })
     searchForBookerPage.enterBookerSearchTerm(booker.email)
     searchForBookerPage.search()
 

--- a/integration_tests/mockApis/prisonerContactRegistry.ts
+++ b/integration_tests/mockApis/prisonerContactRegistry.ts
@@ -3,22 +3,43 @@ import { stubFor } from './wiremock'
 import { ContactDto } from '../../server/data/prisonerContactRegistryApiTypes'
 
 export default {
-  stubGetSocialContacts: ({
+  stubGetAllSocialContacts: ({
     prisonerId,
     contacts,
-    approvedOnly,
   }: {
     prisonerId: string
     contacts: ContactDto[]
-    approvedOnly: boolean
   }): SuperAgentRequest => {
     return stubFor({
       request: {
         method: 'GET',
-        urlPath: `/prisonerContactRegistry/prisoners/${prisonerId}/contacts/social`,
+        urlPath: `/prisonerContactRegistry/v2/prisoners/${prisonerId}/contacts/social`,
         queryParameters: {
-          approvedVisitorsOnly: { equalTo: approvedOnly.toString() },
-          hasDateOfBirth: { equalTo: 'true' },
+          hasDateOfBirth: { equalTo: 'false' },
+          withAddress: { equalTo: 'false' },
+        },
+      },
+      response: {
+        status: 200,
+        headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+        jsonBody: contacts,
+      },
+    })
+  },
+
+  stubGetApprovedSocialContacts: ({
+    prisonerId,
+    contacts,
+  }: {
+    prisonerId: string
+    contacts: ContactDto[]
+  }): SuperAgentRequest => {
+    return stubFor({
+      request: {
+        method: 'GET',
+        urlPath: `/prisonerContactRegistry/v2/prisoners/${prisonerId}/contacts/social/approved`,
+        queryParameters: {
+          hasDateOfBirth: { equalTo: 'false' },
           withAddress: { equalTo: 'false' },
         },
       },

--- a/server/data/prisonerContactRegistryApiClient.test.ts
+++ b/server/data/prisonerContactRegistryApiClient.test.ts
@@ -22,26 +22,40 @@ describe('prisonerContactRegistryApiClient', () => {
     nock.cleanAll()
   })
 
-  describe('getSocialContacts', () => {
-    it('should call get social contacts for given prisoner ID and approvedOnly flag', async () => {
+  describe('getAllSocialContacts', () => {
+    it('should get all social contacts for given prisoner', async () => {
       const prisoner = TestData.permittedPrisonerDto()
       const contacts = [TestData.contact()]
-      const approvedOnly = true
 
       fakePrisonerContactRegistryApi
-        .get(`/prisoners/${prisoner.prisonerId}/contacts/social`)
+        .get(`/v2/prisoners/${prisoner.prisonerId}/contacts/social`)
         .query({
-          approvedVisitorsOnly: approvedOnly,
-          hasDateOfBirth: true,
+          hasDateOfBirth: false,
           withAddress: false,
         })
         .matchHeader('authorization', `Bearer ${token}`)
         .reply(200, contacts)
 
-      const output = await prisonerContactRegistryApiClient.getSocialContacts({
-        prisonerId: prisoner.prisonerId,
-        approvedOnly,
-      })
+      const output = await prisonerContactRegistryApiClient.getAllSocialContacts(prisoner.prisonerId)
+      expect(output).toStrictEqual(contacts)
+    })
+  })
+
+  describe('getApprovedSocialContacts', () => {
+    it('should get all approved social contacts for given prisoner', async () => {
+      const prisoner = TestData.permittedPrisonerDto()
+      const contacts = [TestData.contact()]
+
+      fakePrisonerContactRegistryApi
+        .get(`/v2/prisoners/${prisoner.prisonerId}/contacts/social/approved`)
+        .query({
+          hasDateOfBirth: false,
+          withAddress: false,
+        })
+        .matchHeader('authorization', `Bearer ${token}`)
+        .reply(200, contacts)
+
+      const output = await prisonerContactRegistryApiClient.getApprovedSocialContacts(prisoner.prisonerId)
       expect(output).toStrictEqual(contacts)
     })
   })

--- a/server/data/prisonerContactRegistryApiClient.ts
+++ b/server/data/prisonerContactRegistryApiClient.ts
@@ -9,18 +9,21 @@ export default class PrisonerContactRegistryApiClient {
     this.restClient = new RestClient('prisonerContactRegistryApiClient', config.apis.prisonerContactRegistry, token)
   }
 
-  async getSocialContacts({
-    prisonerId,
-    approvedOnly,
-  }: {
-    prisonerId: string
-    approvedOnly: boolean
-  }): Promise<ContactDto[]> {
+  async getAllSocialContacts(prisonerId: string): Promise<ContactDto[]> {
     return this.restClient.get({
-      path: `/prisoners/${prisonerId}/contacts/social`,
+      path: `/v2/prisoners/${prisonerId}/contacts/social`,
       query: new URLSearchParams({
-        approvedVisitorsOnly: approvedOnly.toString(),
-        hasDateOfBirth: 'true',
+        hasDateOfBirth: 'false',
+        withAddress: 'false',
+      }).toString(),
+    })
+  }
+
+  async getApprovedSocialContacts(prisonerId: string): Promise<ContactDto[]> {
+    return this.restClient.get({
+      path: `/v2/prisoners/${prisonerId}/contacts/social/approved`,
+      query: new URLSearchParams({
+        hasDateOfBirth: 'false',
         withAddress: 'false',
       }).toString(),
     })

--- a/server/middleware/setUpCsrf.ts
+++ b/server/middleware/setUpCsrf.ts
@@ -14,7 +14,7 @@ export default function setUpCsrf(): Router {
       // By default, csrf-sync uses x-csrf-token header, but we use the token in forms and send it in the request body, so change getTokenFromRequest so it grabs from there
       getTokenFromRequest: req => {
         // eslint-disable-next-line no-underscore-dangle
-        return req.body._csrf
+        return req.body?._csrf
       },
     })
 

--- a/server/services/prisonerContactsService.test.ts
+++ b/server/services/prisonerContactsService.test.ts
@@ -24,21 +24,35 @@ describe('Prisoner Contacts service', () => {
   })
 
   describe('getSocialContacts', () => {
-    it('should get social contacts for prisoner', async () => {
+    it('should get social contacts for prisoner - approvedOnly = true', async () => {
       const contacts = [TestData.contact()]
       const prisoner = TestData.permittedPrisonerDto()
 
-      prisonerContactRegistryApiClient.getSocialContacts.mockResolvedValue(contacts)
+      prisonerContactRegistryApiClient.getApprovedSocialContacts.mockResolvedValue(contacts)
       const results = await prisonerContactsService.getSocialContacts({
         username: 'user',
         prisonerId: prisoner.prisonerId,
         approvedOnly: true,
       })
 
-      expect(prisonerContactRegistryApiClient.getSocialContacts).toHaveBeenCalledWith({
+      expect(prisonerContactRegistryApiClient.getApprovedSocialContacts).toHaveBeenCalledWith(prisoner.prisonerId)
+      expect(prisonerContactRegistryApiClient.getAllSocialContacts).not.toHaveBeenCalled()
+      expect(results).toStrictEqual(contacts)
+    })
+
+    it('should get social contacts for prisoner - approvedOnly = false', async () => {
+      const contacts = [TestData.contact()]
+      const prisoner = TestData.permittedPrisonerDto()
+
+      prisonerContactRegistryApiClient.getAllSocialContacts.mockResolvedValue(contacts)
+      const results = await prisonerContactsService.getSocialContacts({
+        username: 'user',
         prisonerId: prisoner.prisonerId,
-        approvedOnly: true,
+        approvedOnly: false,
       })
+
+      expect(prisonerContactRegistryApiClient.getAllSocialContacts).toHaveBeenCalledWith(prisoner.prisonerId)
+      expect(prisonerContactRegistryApiClient.getApprovedSocialContacts).not.toHaveBeenCalled()
       expect(results).toStrictEqual(contacts)
     })
   })

--- a/server/services/prisonerContactsService.ts
+++ b/server/services/prisonerContactsService.ts
@@ -19,6 +19,8 @@ export default class PrisonerContactsService {
     const token = await this.hmppsAuthClient.getSystemClientToken(username)
     const prisonerContactRegistryApiClient = this.prisonerContactRegistryApiClientFactory(token)
 
-    return prisonerContactRegistryApiClient.getSocialContacts({ prisonerId, approvedOnly })
+    return approvedOnly
+      ? prisonerContactRegistryApiClient.getApprovedSocialContacts(prisonerId)
+      : prisonerContactRegistryApiClient.getAllSocialContacts(prisonerId)
   }
 }

--- a/server/views/pages/bookers/booker/addVisitor.njk
+++ b/server/views/pages/bookers/booker/addVisitor.njk
@@ -24,7 +24,9 @@
 
     {% if contacts | length %}
 
-    <p>Showing prisoner's social contacts that are approved, have a date of birth and have not already been added.</p>
+    <p>Showing prisoner's social contacts that are approved and have not already been added.</p>
+
+    <p>Visitors without a date of birth entered cannot be selected.</p>
 
       <form action="/bookers/booker/{{ booker.reference }}/prisoner/{{ prisoner.prisonerId }}/add-visitor" method="POST" novalidate>
         <input type="hidden" name="_csrf" value="{{ csrfToken }}">
@@ -35,7 +37,7 @@
             {
               html:
                 '<div class="govuk-radios__item">' +
-                  '<input class="govuk-radios__input" id="visitor-' + contact.personId + '" name="visitorId" type="radio" value="' + contact.personId + '">' +
+                  '<input class="govuk-radios__input" id="visitor-' + contact.personId + '" name="visitorId" type="radio" value="' + contact.personId + '"' + (" disabled" if not contact.dateOfBirth) + '>' +
                   '<label class="govuk-label govuk-radios__label" for="visitor-' + contact.personId + '">' +
                     '<span class="govuk-visually-hidden">Select contact ' + contact.personId + '</span>' +
                   '</label>' +
@@ -48,8 +50,9 @@
               text: contact.personId
             },
             {
-              html: contact.dateOfBirth | formatDate +
-                '<br>(' + contact.dateOfBirth | displayAge + ')'
+              html: (contact.dateOfBirth | formatDate +
+                '<br>(' + contact.dateOfBirth | displayAge + ')') if contact.dateOfBirth
+                else "Not entered"
             },
             {
               html: visitorRestrictions(contact)


### PR DESCRIPTION
* Move to Contact Registry API v2
* Adding visitors for a booker/prisoner: show visitors without a date of birth, but with **disabled** input so they cannot be added