### PR TITLE
Add button to new contacts DPS service

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -19,6 +19,7 @@ generic-service:
     PRISONER_CONTACT_REGISTRY_API_URL: "https://prisoner-contact-registry-dev.prison.service.justice.gov.uk"
     PRISON_REGISTER_API_URL: "https://prison-register-dev.hmpps.service.justice.gov.uk"
     VISIT_SCHEDULER_API_URL: "https://visit-scheduler-dev.prison.service.justice.gov.uk"
+    CONTACTS_URL: "https://contacts-dev.hmpps.service.justice.gov.uk"
     ENVIRONMENT_NAME: DEV
 
 generic-prometheus-alerts:

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -19,6 +19,7 @@ generic-service:
     PRISONER_CONTACT_REGISTRY_API_URL: "https://prisoner-contact-registry-preprod.prison.service.justice.gov.uk"
     PRISON_REGISTER_API_URL: "https://prison-register-preprod.hmpps.service.justice.gov.uk"
     VISIT_SCHEDULER_API_URL: "https://visit-scheduler-preprod.prison.service.justice.gov.uk"
+    CONTACTS_URL: "https://contacts-preprod.hmpps.service.justice.gov.uk"
     ENVIRONMENT_NAME: PRE-PRODUCTION
 
 generic-prometheus-alerts:

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -16,6 +16,7 @@ generic-service:
     PRISONER_CONTACT_REGISTRY_API_URL: "https://prisoner-contact-registry.prison.service.justice.gov.uk"
     PRISON_REGISTER_API_URL: "https://prison-register.hmpps.service.justice.gov.uk"
     VISIT_SCHEDULER_API_URL: "https://visit-scheduler.prison.service.justice.gov.uk"
+    CONTACTS_URL: "https://contacts.hmpps.service.justice.gov.uk"
 
 generic-prometheus-alerts:
   alertSeverity: visits-alerts

--- a/helm_deploy/values-staging.yaml
+++ b/helm_deploy/values-staging.yaml
@@ -19,6 +19,7 @@ generic-service:
     PRISONER_CONTACT_REGISTRY_API_URL: "https://prisoner-contact-registry-staging.prison.service.justice.gov.uk"
     PRISON_REGISTER_API_URL: "https://prison-register-dev.hmpps.service.justice.gov.uk"
     VISIT_SCHEDULER_API_URL: "https://visit-scheduler-staging.prison.service.justice.gov.uk"
+    CONTACTS_URL: "https://contacts-dev.hmpps.service.justice.gov.uk"
     ENVIRONMENT_NAME: STAGING
     APPLICATIONINSIGHTS_CONNECTION_STRING: null # disable App Insights for staging
 

--- a/server/config.ts
+++ b/server/config.ts
@@ -53,6 +53,7 @@ export default {
     secret: get('SESSION_SECRET', 'app-insecure-default-session', requiredInProduction),
     expiryMinutes: Number(get('WEB_SESSION_TIMEOUT_IN_MINUTES', 120)),
   },
+  contactsUrl: get('CONTACTS_URL', 'https://contacts-dev.hmpps.service.justice.gov.uk', requiredInProduction),
   apis: {
     hmppsAuth: {
       url: get('HMPPS_AUTH_URL', 'http://localhost:9090/auth', requiredInProduction),

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -15,6 +15,7 @@ export default function nunjucksSetup(app: express.Express, applicationInfo: App
 
   app.locals.asset_path = '/assets/'
   app.locals.applicationName = 'Administer visits'
+  app.locals.contactsUrl = config.contactsUrl
   app.locals.environmentName = config.environmentName
   app.locals.environmentNameColour = config.environmentName === 'PRE-PRODUCTION' ? 'govuk-tag--green' : ''
 

--- a/server/views/pages/bookers/booker/bookerPrisonerDetails.njk
+++ b/server/views/pages/bookers/booker/bookerPrisonerDetails.njk
@@ -48,6 +48,13 @@
           classes: "govuk-button--secondary",
           preventDoubleClick: true
         }) }}
+
+        {{ govukButton({
+          text: "View social contacts",
+          href:  contactsUrl + "/prisoner/" + prisoner.prisonerId + "/contacts/list?relationshipStatus=ACTIVE_AND_INACTIVE&relationshipType=S",
+          preventDoubleClick: true
+        }) }}
+
       </form>
     </div>
 


### PR DESCRIPTION
This PR adds a button to the "prisoner details" page which is part of the booker management functionality.

When pressed, the user is taken to the new Contacts DPS page and shown the social visitors for the selected prisoner. The link works across the different environments (DEV, PREPORD etc) to go to the appropriate environment. 